### PR TITLE
All Apps list is now a list of buttons.

### DIFF
--- a/RetiledStart/RetiledStart/Styles/AllAppsEntry.axaml
+++ b/RetiledStart/RetiledStart/Styles/AllAppsEntry.axaml
@@ -20,6 +20,5 @@
 		<Setter Property="BorderThickness" Value="0" />
 		<Setter Property="VerticalContentAlignment" Value="Center" />
 		<Setter Property="Background" Value="Black"/>
-		<Setter Property="BorderBrush" Value="White"/>
 	</Style>
 </Styles>

--- a/RetiledStart/RetiledStart/Styles/AllAppsEntry.axaml
+++ b/RetiledStart/RetiledStart/Styles/AllAppsEntry.axaml
@@ -1,7 +1,17 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
-        <Border Padding="20">
+        <Border>
+			<StackPanel>
+			<Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+				<StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+					<Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+					<!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
+				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
+					<TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				</StackPanel>
+			</Button>
+
 			<Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
 				<StackPanel Classes="RetiledAllAppsEntry_StackPanel" VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 					<Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
@@ -10,6 +20,7 @@
 					<TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 				</StackPanel>
 			</Button>
+				</StackPanel>
         </Border>
     </Design.PreviewWith>
 
@@ -20,5 +31,15 @@
 		<Setter Property="BorderThickness" Value="0" />
 		<Setter Property="VerticalContentAlignment" Value="Center" />
 		<Setter Property="Background" Value="Black"/>
+	</Style>
+
+	<Style Selector="StackPanel.RetiledAllAppsEntry_StackPanel /template/ ContentPresenter">
+		<!-- This part makes regular rectangular buttons look like
+		the Windows Phone buttons. -->
+		<Setter Property="VerticalContentAlignment" Value="Center" />
+		<Setter Property="VerticalAlignment" Value="Center"/>
+		<Setter Property="HorizontalAlignment" Value="Left"/>
+		<Setter Property="Orientation" Value="Horizontal"/>
+		<Setter Property="Margin" Value="0,5"/>
 	</Style>
 </Styles>

--- a/RetiledStart/RetiledStart/Styles/AllAppsEntry.axaml
+++ b/RetiledStart/RetiledStart/Styles/AllAppsEntry.axaml
@@ -1,0 +1,26 @@
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Design.PreviewWith>
+        <Border Padding="20">
+			<Button Classes="RetiledAllAppsEntry" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+				<StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
+					<Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+					<!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
+				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
+					<TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				</StackPanel>
+			</Button>
+        </Border>
+    </Design.PreviewWith>
+
+	<Style Selector="Button.RetiledAllAppsEntry /template/ ContentPresenter">
+		<!-- This part makes regular rectangular buttons look like
+		the Windows Phone buttons. -->
+		<Setter Property="CornerRadius" Value="0" />
+		<Setter Property="BorderThickness" Value="2" />
+		<Setter Property="VerticalContentAlignment" Value="Center" />
+		<Setter Property="HorizontalContentAlignment" Value="Center"/>
+		<Setter Property="Background" Value="Black"/>
+		<Setter Property="BorderBrush" Value="White"/>
+	</Style>
+</Styles>

--- a/RetiledStart/RetiledStart/Styles/AllAppsEntry.axaml
+++ b/RetiledStart/RetiledStart/Styles/AllAppsEntry.axaml
@@ -31,6 +31,7 @@
 		<Setter Property="BorderThickness" Value="0" />
 		<Setter Property="VerticalContentAlignment" Value="Center" />
 		<Setter Property="Background" Value="Black"/>
+		<Setter Property="Margin" Value="0,5"/>
 	</Style>
 
 	<Style Selector="StackPanel.RetiledAllAppsEntry_StackPanel /template/ ContentPresenter">

--- a/RetiledStart/RetiledStart/Styles/AllAppsEntry.axaml
+++ b/RetiledStart/RetiledStart/Styles/AllAppsEntry.axaml
@@ -2,8 +2,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
         <Border Padding="20">
-			<Button Classes="RetiledAllAppsEntry" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-				<StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
+			<Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+				<StackPanel Classes="RetiledAllAppsEntry_StackPanel" VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 					<Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 					<!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -13,13 +13,12 @@
         </Border>
     </Design.PreviewWith>
 
-	<Style Selector="Button.RetiledAllAppsEntry /template/ ContentPresenter">
+	<Style Selector="Button.RetiledAllAppsEntry_Button /template/ ContentPresenter">
 		<!-- This part makes regular rectangular buttons look like
 		the Windows Phone buttons. -->
 		<Setter Property="CornerRadius" Value="0" />
-		<Setter Property="BorderThickness" Value="2" />
+		<Setter Property="BorderThickness" Value="0" />
 		<Setter Property="VerticalContentAlignment" Value="Center" />
-		<Setter Property="HorizontalContentAlignment" Value="Center"/>
 		<Setter Property="Background" Value="Black"/>
 		<Setter Property="BorderBrush" Value="White"/>
 	</Style>

--- a/RetiledStart/RetiledStart/Styles/AllAppsEntry.axaml
+++ b/RetiledStart/RetiledStart/Styles/AllAppsEntry.axaml
@@ -27,11 +27,9 @@
 	<Style Selector="Button.RetiledAllAppsEntry_Button /template/ ContentPresenter">
 		<!-- This part makes regular rectangular buttons look like
 		the Windows Phone buttons. -->
-		<Setter Property="CornerRadius" Value="0" />
 		<Setter Property="BorderThickness" Value="0" />
 		<Setter Property="VerticalContentAlignment" Value="Center" />
 		<Setter Property="Background" Value="Black"/>
-		<Setter Property="Margin" Value="0,5"/>
 	</Style>
 
 	<Style Selector="StackPanel.RetiledAllAppsEntry_StackPanel /template/ ContentPresenter">
@@ -40,7 +38,6 @@
 		<Setter Property="VerticalContentAlignment" Value="Center" />
 		<Setter Property="VerticalAlignment" Value="Center"/>
 		<Setter Property="HorizontalAlignment" Value="Left"/>
-		<Setter Property="Margin" Value="0,5"/>
 	</Style>
 
 	<Style Selector="Rectangle.RetiledAllAppsEntry_Rectangle">

--- a/RetiledStart/RetiledStart/Styles/AllAppsEntry.axaml
+++ b/RetiledStart/RetiledStart/Styles/AllAppsEntry.axaml
@@ -5,7 +5,7 @@
 			<StackPanel>
 			<Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
 				<StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
-					<Rectangle Classes="RetiledAllAppsEntry_Rectangle" VerticalAlignment="Center" Height="50" Width="50"/>
+					<Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 					<!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 					<TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
@@ -13,8 +13,8 @@
 			</Button>
 
 			<Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-				<StackPanel Classes="RetiledAllAppsEntry_StackPanel" VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-					<Rectangle Classes="RetiledAllAppsEntry_Rectangle" VerticalAlignment="Center" Height="50" Width="50"/>
+				<StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+					<Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 					<!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 					<TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>

--- a/RetiledStart/RetiledStart/Styles/AllAppsEntry.axaml
+++ b/RetiledStart/RetiledStart/Styles/AllAppsEntry.axaml
@@ -5,19 +5,19 @@
 			<StackPanel>
 			<Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
 				<StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
-					<Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+					<Rectangle Classes="RetiledAllAppsEntry_Rectangle" VerticalAlignment="Center" Height="50" Width="50"/>
 					<!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-					<TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+					<TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 				</StackPanel>
 			</Button>
 
 			<Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
 				<StackPanel Classes="RetiledAllAppsEntry_StackPanel" VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-					<Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+					<Rectangle Classes="RetiledAllAppsEntry_Rectangle" VerticalAlignment="Center" Height="50" Width="50"/>
 					<!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-					<TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+					<TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 				</StackPanel>
 			</Button>
 				</StackPanel>
@@ -39,7 +39,19 @@
 		<Setter Property="VerticalContentAlignment" Value="Center" />
 		<Setter Property="VerticalAlignment" Value="Center"/>
 		<Setter Property="HorizontalAlignment" Value="Left"/>
-		<Setter Property="Orientation" Value="Horizontal"/>
 		<Setter Property="Margin" Value="0,5"/>
+	</Style>
+
+	<Style Selector="Rectangle.RetiledAllAppsEntry_Rectangle">
+		<!-- This part makes regular rectangular buttons look like
+		the Windows Phone buttons. -->
+		<Setter Property="VerticalAlignment" Value="Center"/>
+		<Setter Property="Fill" Value="#0050ef"/>
+	</Style>
+
+	<Style Selector="TextBlock.RetiledAllAppsEntry_TextBlock">
+		<!-- This part makes regular rectangular buttons look like
+		the Windows Phone buttons. -->
+		<Setter Property="VerticalAlignment" Value="Center"/>
 	</Style>
 </Styles>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -32,7 +32,7 @@
 	  </Button>
 		  </StackPanel>
 	  
-	  <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Hidden" HorizontalScrollBarVisibility="Disabled">
+	  <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
 	  <StackPanel VerticalAlignment="Top" Background="Black">
 		  <!-- Temporary All Apps list in a ListBox.
 		  This doesn't look very good, but it's better than

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -32,8 +32,8 @@
 	  </Button>
 		  </StackPanel>
 	  
-	  <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-	  <StackPanel VerticalAlignment="Top" Background="Black">
+	  <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Disabled">
+	  <StackPanel VerticalAlignment="Top" Background="Black" Width="300">
 		  <!-- Temporary All Apps list in a ListBox.
 		  This doesn't look very good, but it's better than
 		  nothing. Using an ItemsRepeater would be a good idea.

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -33,7 +33,7 @@
 		  </StackPanel>
 	  
 	  <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Disabled">
-	  <StackPanel VerticalAlignment="Top" Background="Black" Width="300">
+	  <StackPanel HorizontalAlignment="Left" VerticalAlignment="Top" Background="Black" Width="310">
 		  <!-- Temporary All Apps list in a ListBox.
 		  This doesn't look very good, but it's better than
 		  nothing. Using an ItemsRepeater would be a good idea.

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -33,7 +33,7 @@
 		  </StackPanel>
 	  
 	  <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Hidden" HorizontalScrollBarVisibility="Disabled">
-	  <ItemsControl VerticalAlignment="Top" Background="Black">
+	  <StackPanel VerticalAlignment="Top" Background="Black">
 		  <!-- Temporary All Apps list in a ListBox.
 		  This doesn't look very good, but it's better than
 		  nothing. Using an ItemsRepeater would be a good idea.
@@ -55,14 +55,14 @@
 		  Maybe that'll require using buttons. Not sure how
 		  to make the buttons stretch the the side of the
 		  screen, though.-->
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 			      <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 			      <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
+		  </Button>
 
 		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
@@ -250,7 +250,7 @@
 			  </StackPanel>
 		  </ListBoxItem>
 		  
-		  </ItemsControl>
+		  </StackPanel>
 		  </ScrollViewer>
   </Grid>
 </UserControl>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -55,12 +55,12 @@
 		  Maybe that'll require using buttons. Not sure how
 		  to make the buttons stretch the the side of the
 		  screen, though.-->
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-			      <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
-			      <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
+				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
 

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -32,7 +32,7 @@
 	  </Button>
 		  </StackPanel>
 	  
-	  <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Disabled">
+	  <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
 	  <StackPanel HorizontalAlignment="Left" VerticalAlignment="Top" Background="Black" Width="310">
 		  <!-- Temporary All Apps list in a ListBox.
 		  This doesn't look very good, but it's better than

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -64,191 +64,191 @@
 			  </StackPanel>
 		  </Button>
 
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
+		  </Button>
 
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
-		  <ListBoxItem Margin="0,5" Height="55" VerticalContentAlignment="Center">
+		  </Button>
+		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
-		  </ListBoxItem>
+		  </Button>
 		  
 		  </StackPanel>
 		  </ScrollViewer>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -55,8 +55,8 @@
 		  Maybe that'll require using buttons. Not sure how
 		  to make the buttons stretch the the side of the
 		  screen, though.-->
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -64,144 +64,144 @@
 			  </StackPanel>
 		  </Button>
 
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -64,189 +64,148 @@
 			  </StackPanel>
 		  </Button>
 
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
+		  <Button Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+			  <StackPanel Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
-			  </StackPanel>
-		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
-				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
-				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
-			  </StackPanel>
-		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
-				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
-				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
-			  </StackPanel>
-		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
-				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
-				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
-			  </StackPanel>
-		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
-				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
-				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
-			  </StackPanel>
-		  </Button>
-		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
-			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
-				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
-				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
-				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
-				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
+				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
 		  

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -56,7 +56,7 @@
 		  to make the buttons stretch the the side of the
 		  screen, though.-->
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -65,7 +65,7 @@
 		  </Button>
 
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -73,7 +73,7 @@
 			  </StackPanel>
 		  </Button>
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -81,7 +81,7 @@
 			  </StackPanel>
 		  </Button>
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -89,7 +89,7 @@
 			  </StackPanel>
 		  </Button>
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -97,7 +97,7 @@
 			  </StackPanel>
 		  </Button>
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -105,7 +105,7 @@
 			  </StackPanel>
 		  </Button>
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -113,7 +113,7 @@
 			  </StackPanel>
 		  </Button>
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -121,7 +121,7 @@
 			  </StackPanel>
 		  </Button>
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -129,7 +129,7 @@
 			  </StackPanel>
 		  </Button>
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -137,7 +137,7 @@
 			  </StackPanel>
 		  </Button>
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -145,7 +145,7 @@
 			  </StackPanel>
 		  </Button>
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -153,7 +153,7 @@
 			  </StackPanel>
 		  </Button>
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -161,7 +161,7 @@
 			  </StackPanel>
 		  </Button>
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -169,7 +169,7 @@
 			  </StackPanel>
 		  </Button>
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -177,7 +177,7 @@
 			  </StackPanel>
 		  </Button>
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -185,7 +185,7 @@
 			  </StackPanel>
 		  </Button>
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -193,7 +193,7 @@
 			  </StackPanel>
 		  </Button>
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
@@ -201,7 +201,7 @@
 			  </StackPanel>
 		  </Button>
 		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
-			  <StackPanel Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
+			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 				  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -55,7 +55,7 @@
 		  Maybe that'll require using buttons. Not sure how
 		  to make the buttons stretch the the side of the
 		  screen, though.-->
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 			      <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 			      <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -64,7 +64,7 @@
 			  </StackPanel>
 		  </Button>
 
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -72,7 +72,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -80,7 +80,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -88,7 +88,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -96,7 +96,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -104,7 +104,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -112,7 +112,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -120,7 +120,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -128,7 +128,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -136,7 +136,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -144,7 +144,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -152,7 +152,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -160,7 +160,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -168,7 +168,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -177,7 +177,7 @@
 			  </StackPanel>
 		  </Button>
 
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -185,7 +185,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -193,7 +193,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -201,7 +201,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -209,7 +209,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -217,7 +217,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -225,7 +225,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -233,7 +233,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -241,7 +241,7 @@
 				  <TextBlock VerticalAlignment="Center" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Margin="0,5" Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
+		  <Button Height="55" Width="{Binding $parent[Window].Width}" VerticalContentAlignment="Center">
 			  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Left" Orientation="Horizontal" Spacing="10">
 				  <Rectangle VerticalAlignment="Center" Height="50" Width="50" Fill="#0050ef" />
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -55,7 +55,7 @@
 		  Maybe that'll require using buttons. Not sure how
 		  to make the buttons stretch the the side of the
 		  screen, though.-->
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -64,7 +64,7 @@
 			  </StackPanel>
 		  </Button>
 
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -72,7 +72,7 @@
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -80,7 +80,7 @@
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -88,7 +88,7 @@
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -96,7 +96,7 @@
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -104,7 +104,7 @@
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -112,7 +112,7 @@
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -120,7 +120,7 @@
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -128,7 +128,7 @@
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -136,7 +136,7 @@
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -144,7 +144,7 @@
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -152,7 +152,7 @@
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -160,7 +160,7 @@
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -168,7 +168,7 @@
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -176,7 +176,7 @@
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -184,7 +184,7 @@
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -192,7 +192,7 @@
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
@@ -200,7 +200,7 @@
 				  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" FontSize="20">firefox</TextBlock>
 			  </StackPanel>
 		  </Button>
-		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="55" Width="{Binding $parent[Window].Width}">
+		  <Button Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" Width="{Binding $parent[Window].Width}">
 			  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 				  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 				  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:

--- a/RetiledStart/RetiledStart/Views/MainWindow.axaml
+++ b/RetiledStart/RetiledStart/Views/MainWindow.axaml
@@ -45,6 +45,7 @@ respective people and companies/organizations.
 	<Window.Styles>
 		<StyleInclude Source="avares://RetiledStart/Styles/StartTile.axaml" />
 		<StyleInclude Source="avares://RetiledStart/Styles/RoundButton.axaml" />
+		<StyleInclude Source="avares://RetiledStart/Styles/AllAppsEntry.axaml" />
 	<!-- This page helped me get the styles in here:
 	https://medium.com/swlh/cross-platform-gui-for-dotnet-applications-bbd284709600-->
 	</Window.Styles>


### PR DESCRIPTION
This'll make it easier to run applications using the `Command` thing. There's also a visible gap between apps like WP8.1, though scrolling this list using the gap isn't possible since it's part of the button. For now, the scrollbar on the side can be dragged.