### PR TITLE
Show desktop entry names in the All Apps list instead of filenames.

### DIFF
--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -78,6 +78,7 @@ namespace RetiledStart.ViewModels
         public object Convert(IList<object> values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             string? DesktopEntryName = values[0] as string;
+            Debug.WriteLine(desktopEntryStuff.getInfo(DesktopEntryName, "Name"));
             return desktopEntryStuff.getInfo(DesktopEntryName, "Name");
         }
 

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -77,7 +77,7 @@ namespace RetiledStart.ViewModels
     {
         public object Convert(IList<object> values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            return desktopEntryStuff.getInfo((string)parameter, "Name");
+            return desktopEntryStuff.getInfo((string)values[0], "Name");
         }
 
         public object? ConvertBack(IList<object> values, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -68,16 +68,19 @@ namespace RetiledStart.ViewModels
 
     }
 
-    // IValueConverter for the app list.
-    // This is from MSDN.
-    public class AppNameConverter : IValueConverter
+    // IMultiValueConverter for the app list.
+    // Can't bind with an IValueConverter, so I have
+    // to use this.
+    // This is from MSDN:
+    // https://docs.microsoft.com/en-us/dotnet/api/system.windows.data.imultivalueconverter?view=net-5.0
+    public class AppNameConverter : IMultiValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object Convert(IList<object> values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             return desktopEntryStuff.getInfo((string)parameter, "Name");
         }
 
-        public object? ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object? ConvertBack(IList<object> values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             return "null";
         }

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -77,6 +77,7 @@ namespace RetiledStart.ViewModels
         public object Convert(IList<object> values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             string DesktopEntryName = values[0] as string;
+            Debug.WriteLine(values[0]);
             Debug.WriteLine(desktopEntryStuff.getInfo(DesktopEntryName, "Name"));
             return desktopEntryStuff.getInfo(DesktopEntryName, "Name");
         }

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -65,34 +65,6 @@ namespace RetiledStart.ViewModels
             
         }
 
-        // Property for storing the current app name.
-        // From here:
-        // https://social.technet.microsoft.com/wiki/contents/articles/30936.wpf-multibinding-and-imultivalueconverter.aspx
-        private string appname;
-        public string AppName
-        {
-            get
-            {
-                return appname;
-            }
-            set
-            {
-                appname = value;
-                OnPropertyChanged("AppName");
-            }
-        }
-
-        // PropertyChanged event handler.
-        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-        public void OnPropertyChanged(string propertyName)
-        {
-            System.ComponentModel.PropertyChangedEventHandler handle = PropertyChanged;
-            if (handle != null)
-            {
-                handle(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
-            }
-        }
-
     }
 
     // IMultiValueConverter for the app list.

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -79,7 +79,7 @@ namespace RetiledStart.ViewModels
 
         public object? ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            return null;
+            return "null";
         }
     }
 }

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -70,7 +70,7 @@ namespace RetiledStart.ViewModels
 
     // IValueConverter for the app list.
     // This is from MSDN.
-    public class AppListItemTextConverter : IValueConverter
+    public class AppNameConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -74,7 +74,12 @@ namespace RetiledStart.ViewModels
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            return (desktopEntryStuff.getInfo((string)parameter, "Name"));
+            return desktopEntryStuff.getInfo((string)parameter, "Name");
+        }
+
+        public object? ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return null;
         }
     }
 }

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -67,11 +67,12 @@ namespace RetiledStart.ViewModels
 
     }
 
-    // IMultiValueConverter for the app list.
-    // Can't bind with an IValueConverter, so I have
-    // to use this.
+    // IValueConverter for the app list.
+    // Ended up not using IMultiValueConverter because it just didn't
+    // work as I needed it to.
     // This is from MSDN:
-    // https://docs.microsoft.com/en-us/dotnet/api/system.windows.data.imultivalueconverter?view=net-5.0
+    // https://docs.microsoft.com/en-us/dotnet/desktop/wpf/data/?view=netdesktop-5.0#data-conversion
+
     public class AppNameConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -65,6 +65,22 @@ namespace RetiledStart.ViewModels
             
         }
 
+        // Property for storing the current app name.
+        // From here:
+        // https://social.technet.microsoft.com/wiki/contents/articles/30936.wpf-multibinding-and-imultivalueconverter.aspx
+        private string appname;
+        public string AppName
+        {
+            get
+            {
+                return appname;
+            }
+            set
+            {
+                appname = value;
+                OnPropertyChanged("AppName");
+            }
+        }
 
     }
 

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -72,6 +72,9 @@ namespace RetiledStart.ViewModels
     // This is from MSDN.
     public class AppListItemTextConverter : IValueConverter
     {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
 
+        }
     }
 }

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -82,6 +82,17 @@ namespace RetiledStart.ViewModels
             }
         }
 
+        // PropertyChanged event handler.
+        public event PropertyChangedEventHandler PropertyChanged;
+        public void OnPropertyChanged(string propertyName)
+        {
+            PropertyCHangedEventHandler handle = PropertyChanged;
+            if (handle != null)
+            {
+                handle(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
+
     }
 
     // IMultiValueConverter for the app list.

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -74,7 +74,7 @@ namespace RetiledStart.ViewModels
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-
+            return (desktopEntryStuff.getInfo((string)parameter, "Name"));
         }
     }
 }

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -76,8 +76,8 @@ namespace RetiledStart.ViewModels
     {
         public object Convert(IList<object> values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            string DesktopEntryName = (string)values[0];
-            Debug.WriteLine((string)values[0]);
+            string? DesktopEntryName = values[0] as string;
+            Debug.WriteLine(values[0] as string);
             Debug.WriteLine(desktopEntryStuff.getInfo(DesktopEntryName, "Name"));
             return desktopEntryStuff.getInfo(DesktopEntryName, "Name");
         }

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -72,19 +72,19 @@ namespace RetiledStart.ViewModels
     // to use this.
     // This is from MSDN:
     // https://docs.microsoft.com/en-us/dotnet/api/system.windows.data.imultivalueconverter?view=net-5.0
-    public class AppNameConverter : IMultiValueConverter
+    public class AppNameConverter : IValueConverter
     {
-        public object Convert(IList<object> values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            string? DesktopEntryName = values[0] as string;
-            Debug.WriteLine(values[0] as string);
+            string DesktopEntryName = value as string;
+            Debug.WriteLine(DesktopEntryName);
             Debug.WriteLine(desktopEntryStuff.getInfo(DesktopEntryName, "Name"));
             return desktopEntryStuff.getInfo(DesktopEntryName, "Name");
         }
 
-        public object? ConvertBack(IList<object> values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            return "null";
+            return null;
         }
     }
 }

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -83,13 +83,13 @@ namespace RetiledStart.ViewModels
         }
 
         // PropertyChanged event handler.
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
         public void OnPropertyChanged(string propertyName)
         {
-            PropertyCHangedEventHandler handle = PropertyChanged;
+            System.ComponentModel.PropertyChangedEventHandler handle = PropertyChanged;
             if (handle != null)
             {
-                handle(this, new PropertyChangedEventArgs(propertyName));
+                handle(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
             }
         }
 

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -77,7 +77,6 @@ namespace RetiledStart.ViewModels
         public object Convert(IList<object> values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             string DesktopEntryName = values[0] as string;
-            Debug.WriteLine(parameter);
             Debug.WriteLine(desktopEntryStuff.getInfo(DesktopEntryName, "Name"));
             return desktopEntryStuff.getInfo(DesktopEntryName, "Name");
         }

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using Avalonia.Data.Converters;
 using libdotdesktop_standard;
 using ReactiveUI;
 
@@ -64,6 +65,13 @@ namespace RetiledStart.ViewModels
             
         }
 
+
+    }
+
+    // IValueConverter for the app list.
+    // This is from MSDN.
+    public class AppListItemTextConverter : IValueConverter
+    {
 
     }
 }

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -77,7 +77,8 @@ namespace RetiledStart.ViewModels
     {
         public object Convert(IList<object> values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            return desktopEntryStuff.getInfo((string)values[0], "Name");
+            string? DesktopEntryName = values[0] as string;
+            return desktopEntryStuff.getInfo(DesktopEntryName, "Name");
         }
 
         public object? ConvertBack(IList<object> values, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -76,8 +76,8 @@ namespace RetiledStart.ViewModels
     {
         public object Convert(IList<object> values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            string DesktopEntryName = values[0] as string;
-            Debug.WriteLine(values[0]);
+            string DesktopEntryName = (string)values[0];
+            Debug.WriteLine((string)values[0]);
             Debug.WriteLine(desktopEntryStuff.getInfo(DesktopEntryName, "Name"));
             return desktopEntryStuff.getInfo(DesktopEntryName, "Name");
         }

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -77,7 +77,8 @@ namespace RetiledStart.ViewModels
     {
         public object Convert(IList<object> values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            string? DesktopEntryName = values[0] as string;
+            string DesktopEntryName = values[0] as string;
+            Debug.WriteLine(DesktopEntryName);
             Debug.WriteLine(desktopEntryStuff.getInfo(DesktopEntryName, "Name"));
             return desktopEntryStuff.getInfo(DesktopEntryName, "Name");
         }

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -77,7 +77,7 @@ namespace RetiledStart.ViewModels
         public object Convert(IList<object> values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             string DesktopEntryName = values[0] as string;
-            Debug.WriteLine(DesktopEntryName);
+            Debug.WriteLine(parameter);
             Debug.WriteLine(desktopEntryStuff.getInfo(DesktopEntryName, "Name"));
             return desktopEntryStuff.getInfo(DesktopEntryName, "Name");
         }

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -72,7 +72,7 @@
 									  <!-- We need to use multibinding:
 									  https://www.codearsenal.net/2013/12/wpf-multibinding-example.html -->
 									  <MultiBinding Converter="{StaticResource AppListItemTextConverter}">
-										  <Binding />
+										  <Binding Path="CommandParameter" RelativeSource="{RelativeSource  AncestorType=Button}"/>
 									  </MultiBinding>
 								  </TextBlock.Text>
 							  </TextBlock>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -67,9 +67,9 @@
 							  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 							  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 							  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" 
-										 Text="{Binding,
+										 Text="{Binding Value,
 										 Converter={StaticResource AppListItemTextConverter},
-										 ConverterParameter=Binding}" TextTrimming="CharacterEllipsis" FontSize="20"/>
+										 ConverterParameter=Binding Value}" TextTrimming="CharacterEllipsis" FontSize="20"/>
 							  <!-- A converter is necessary to get the text from the file. 
 							  https://stackoverflow.com/a/11104834
 							  https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.data.ivalueconverter?view=winui-3.0 -->

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -72,7 +72,7 @@
 									  <!-- We need to use multibinding:
 									  https://www.codearsenal.net/2013/12/wpf-multibinding-example.html -->
 									  <MultiBinding Converter="{StaticResource AppListItemTextConverter}">
-										  <Binding Path="$parent"/>
+										  <Binding Path="."/>
 									  </MultiBinding>
 								  </TextBlock.Text>
 							  </TextBlock>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -67,9 +67,9 @@
 							  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 							  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 							  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" 
-										 Text="{Binding Value,
+										 Text="{Binding,
 										 Converter={StaticResource AppListItemTextConverter},
-										 ConverterParameter=Binding Value}" TextTrimming="CharacterEllipsis" FontSize="20"/>
+										 ConverterParameter={Binding}}" TextTrimming="CharacterEllipsis" FontSize="20"/>
 							  <!-- A converter is necessary to get the text from the file. 
 							  https://stackoverflow.com/a/11104834
 							  https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.data.ivalueconverter?view=winui-3.0 -->

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -72,7 +72,7 @@
 									  <!-- We need to use multibinding:
 									  https://www.codearsenal.net/2013/12/wpf-multibinding-example.html -->
 									  <MultiBinding Converter="{StaticResource AppListItemTextConverter}">
-										  <Binding Path=""/>
+										  <Binding />
 									  </MultiBinding>
 								  </TextBlock.Text>
 							  </TextBlock>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -60,7 +60,9 @@
 							  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 							  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 							  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" 
-										 Text="{Binding}" TextTrimming="CharacterEllipsis" FontSize="20"/>
+										 Text="{Binding,
+										 Converter={StaticResource AppListItemTextConverter},
+										 ConverterParameter=Binding}" TextTrimming="CharacterEllipsis" FontSize="20"/>
 							  <!-- A converter is necessary to get the text from the file. 
 							  https://stackoverflow.com/a/11104834
 							  https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.data.ivalueconverter?view=winui-3.0 -->

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -11,6 +11,9 @@
 		<StyleInclude Source="avares://RetiledStart/Styles/RoundButton.axaml" />
 		</UserControl.Styles>
 	<UserControl.Resources>
+		<!-- Note: The xmlns:local thing where this is defined
+		needs to be "RetiledStart.ViewModels", or it won't find
+		the converter. -->
 		<local:AppNameConverter x:Key="AppListItemTextConverter"/>
 	</UserControl.Resources>
   <Grid Margin="0,10,0,0" ColumnDefinitions="30,*">

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -72,7 +72,7 @@
 									  <!-- We need to use multibinding:
 									  https://www.codearsenal.net/2013/12/wpf-multibinding-example.html -->
 									  <MultiBinding Converter="{StaticResource AppListItemTextConverter}">
-										  <Binding Source="{Binding}"/>
+										  <Binding Source="{StaticResource Binding}"/>
 									  </MultiBinding>
 								  </TextBlock.Text>
 							  </TextBlock>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-			 xmlns:local="clr-namespace:RetiledStart"
+			 xmlns:local="clr-namespace:RetiledStart.ViewModels;assembly=RetiledStart"
              mc:Ignorable="d" d:DesignWidth="360" d:DesignHeight="720"
              x:Class="RetiledStart.Views.AllAppsView">
 	<UserControl.Styles>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -72,6 +72,7 @@
 									  <!-- We need to use multibinding:
 									  https://www.codearsenal.net/2013/12/wpf-multibinding-example.html -->
 									  <MultiBinding Converter="{StaticResource AppListItemTextConverter}">
+										  <Binding Path="."/>
 										  <Binding Path="CommandParameter" RelativeSource="{RelativeSource  AncestorType=Button}"/>
 									  </MultiBinding>
 								  </TextBlock.Text>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -67,12 +67,13 @@
 							  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 							  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 							  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" 
-										 Text="{Binding,
-										 Converter={StaticResource AppListItemTextConverter},
-										 ConverterParameter={Binding}}" TextTrimming="CharacterEllipsis" FontSize="20">
+										 TextTrimming="CharacterEllipsis" FontSize="20">
 								  <TextBlock.Text>
 									  <!-- We need to use multibinding:
 									  https://www.codearsenal.net/2013/12/wpf-multibinding-example.html -->
+									  <MultiBinding Converter="{StaticResource AppListItemTextConverter}">
+										  <Binding Path="."/>
+									  </MultiBinding>
 								  </TextBlock.Text>
 							  </TextBlock>
 							  <!-- A converter is necessary to get the text from the file. 

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -68,8 +68,7 @@
 							  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 							  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" 
 										 TextTrimming="CharacterEllipsis" FontSize="20"
-										 Text="{Binding, Converter={StaticResource AppListItemTextConverter},
-										 ConverterParameter={Binding}">
+										 Text="{Binding Converter={StaticResource AppListItemTextConverter}}">
 								  <!--<TextBlock.Text>
 									  --><!-- We need to use multibinding:
 									  https://www.codearsenal.net/2013/12/wpf-multibinding-example.html --><!--

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -72,7 +72,7 @@
 									  <!-- We need to use multibinding:
 									  https://www.codearsenal.net/2013/12/wpf-multibinding-example.html -->
 									  <MultiBinding Converter="{StaticResource AppListItemTextConverter}">
-										  <Binding Source="{StaticResource Binding}"/>
+										  <Binding Source="{Binding}"/>
 									  </MultiBinding>
 								  </TextBlock.Text>
 							  </TextBlock>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -72,8 +72,7 @@
 									  <!-- We need to use multibinding:
 									  https://www.codearsenal.net/2013/12/wpf-multibinding-example.html -->
 									  <MultiBinding Converter="{StaticResource AppListItemTextConverter}">
-										  <Binding Path="."/>
-										  <MultiBinding.ConverterParameter>"{Binding}"</MultiBinding.ConverterParameter>
+										  <Binding Path=""/>
 									  </MultiBinding>
 								  </TextBlock.Text>
 							  </TextBlock>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:local="clr-namespace:RetiledStart;assembly=RetiledStart"
              mc:Ignorable="d" d:DesignWidth="360" d:DesignHeight="720"
              x:Class="RetiledStart.Views.AllAppsView">
 	<UserControl.Styles>
@@ -9,6 +10,9 @@
 		idea of what they look like. -->
 		<StyleInclude Source="avares://RetiledStart/Styles/RoundButton.axaml" />
 		</UserControl.Styles>
+	<UserControl.Resources>
+		<local:AppListItemTextConverter x:Key="AppListItemTextConverter"/>
+	</UserControl.Resources>
   <Grid Margin="0,10,0,0" ColumnDefinitions="30,*">
 	  
 	  <StackPanel Margin="10">

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -69,18 +69,13 @@
 							  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" 
 										 TextTrimming="CharacterEllipsis" FontSize="20"
 										 Text="{Binding Converter={StaticResource AppListItemTextConverter}}">
-								  <!--<TextBlock.Text>
-									  --><!-- We need to use multibinding:
-									  https://www.codearsenal.net/2013/12/wpf-multibinding-example.html --><!--
-									  <MultiBinding Converter="{StaticResource AppListItemTextConverter}" Mode="OneWay">
-										  <Binding Path="CommandParameter" RelativeSource="{RelativeSource  AncestorType=Button}"/>
-									  </MultiBinding>
-								  </TextBlock.Text>-->
+								  <!-- Figuring this out was a mess, but this SO answer ended
+								  up being super helpful:
+								  https://stackoverflow.com/a/39869384 -->
 							  </TextBlock>
 							  <!-- A converter is necessary to get the text from the file. 
 							  https://stackoverflow.com/a/11104834
-							  https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.data.ivalueconverter?view=winui-3.0
-							  The IValueConverter won't work because it doesn't support binding parameters. -->
+							  https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.data.ivalueconverter?view=winui-3.0 -->
 						  </StackPanel>
 					  </Button>
 				  </DataTemplate>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -72,7 +72,7 @@
 									  <!-- We need to use multibinding:
 									  https://www.codearsenal.net/2013/12/wpf-multibinding-example.html -->
 									  <MultiBinding Converter="{StaticResource AppListItemTextConverter}">
-										  <Binding Path="$self"/>
+										  <Binding Path="$parent"/>
 									  </MultiBinding>
 								  </TextBlock.Text>
 							  </TextBlock>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -73,6 +73,7 @@
 									  https://www.codearsenal.net/2013/12/wpf-multibinding-example.html -->
 									  <MultiBinding Converter="{StaticResource AppListItemTextConverter}">
 										  <Binding Path="."/>
+										  <MultiBinding.ConverterParameter>"{Binding}"</MultiBinding.ConverterParameter>
 									  </MultiBinding>
 								  </TextBlock.Text>
 							  </TextBlock>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -72,7 +72,7 @@
 									  <!-- We need to use multibinding:
 									  https://www.codearsenal.net/2013/12/wpf-multibinding-example.html -->
 									  <MultiBinding Converter="{StaticResource AppListItemTextConverter}">
-										  <Binding Path="."/>
+										  <Binding Source="{Binding}"/>
 									  </MultiBinding>
 								  </TextBlock.Text>
 							  </TextBlock>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -72,7 +72,8 @@
 										 ConverterParameter={Binding}}" TextTrimming="CharacterEllipsis" FontSize="20"/>
 							  <!-- A converter is necessary to get the text from the file. 
 							  https://stackoverflow.com/a/11104834
-							  https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.data.ivalueconverter?view=winui-3.0 -->
+							  https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.data.ivalueconverter?view=winui-3.0
+							  The IValueConverter won't work because it doesn't support binding parameters. -->
 						  </StackPanel>
 					  </Button>
 				  </DataTemplate>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -67,15 +67,16 @@
 							  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:
 							  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 							  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" 
-										 TextTrimming="CharacterEllipsis" FontSize="20">
-								  <TextBlock.Text>
-									  <!-- We need to use multibinding:
-									  https://www.codearsenal.net/2013/12/wpf-multibinding-example.html -->
-									  <MultiBinding Converter="{StaticResource AppListItemTextConverter}">
-										  <Binding Path="."/>
+										 TextTrimming="CharacterEllipsis" FontSize="20"
+										 Text="{Binding, Converter={StaticResource AppListItemTextConverter},
+										 ConverterParameter={Binding}">
+								  <!--<TextBlock.Text>
+									  --><!-- We need to use multibinding:
+									  https://www.codearsenal.net/2013/12/wpf-multibinding-example.html --><!--
+									  <MultiBinding Converter="{StaticResource AppListItemTextConverter}" Mode="OneWay">
 										  <Binding Path="CommandParameter" RelativeSource="{RelativeSource  AncestorType=Button}"/>
 									  </MultiBinding>
-								  </TextBlock.Text>
+								  </TextBlock.Text>-->
 							  </TextBlock>
 							  <!-- A converter is necessary to get the text from the file. 
 							  https://stackoverflow.com/a/11104834

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-			 xmlns:local="clr-namespace:RetiledStart;assembly=RetiledStart"
+			 xmlns:local="clr-namespace:RetiledStart"
              mc:Ignorable="d" d:DesignWidth="360" d:DesignHeight="720"
              x:Class="RetiledStart.Views.AllAppsView">
 	<UserControl.Styles>
@@ -11,7 +11,7 @@
 		<StyleInclude Source="avares://RetiledStart/Styles/RoundButton.axaml" />
 		</UserControl.Styles>
 	<UserControl.Resources>
-		<local:AppListItemTextConverter x:Key="AppListItemTextConverter"/>
+		<local:AppNameConverter x:Key="AppListItemTextConverter"/>
 	</UserControl.Resources>
   <Grid Margin="0,10,0,0" ColumnDefinitions="30,*">
 	  

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -69,7 +69,12 @@
 							  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" 
 										 Text="{Binding,
 										 Converter={StaticResource AppListItemTextConverter},
-										 ConverterParameter={Binding}}" TextTrimming="CharacterEllipsis" FontSize="20"/>
+										 ConverterParameter={Binding}}" TextTrimming="CharacterEllipsis" FontSize="20">
+								  <TextBlock.Text>
+									  <!-- We need to use multibinding:
+									  https://www.codearsenal.net/2013/12/wpf-multibinding-example.html -->
+								  </TextBlock.Text>
+							  </TextBlock>
 							  <!-- A converter is necessary to get the text from the file. 
 							  https://stackoverflow.com/a/11104834
 							  https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.data.ivalueconverter?view=winui-3.0

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -72,7 +72,7 @@
 									  <!-- We need to use multibinding:
 									  https://www.codearsenal.net/2013/12/wpf-multibinding-example.html -->
 									  <MultiBinding Converter="{StaticResource AppListItemTextConverter}">
-										  <Binding Source="{Binding}"/>
+										  <Binding Path="$self"/>
 									  </MultiBinding>
 								  </TextBlock.Text>
 							  </TextBlock>

--- a/RetiledStart/RetiledStart/Views/MainWindow.axaml
+++ b/RetiledStart/RetiledStart/Views/MainWindow.axaml
@@ -50,7 +50,7 @@ respective people and companies/organizations.
 	https://medium.com/swlh/cross-platform-gui-for-dotnet-applications-bbd284709600-->
 	</Window.Styles>
 
-    <Design.DataContext>
+	<Design.DataContext>
         <vm:MainWindowViewModel/>
     </Design.DataContext>
 


### PR DESCRIPTION
This was a mess to figure out, but the All Apps list now displays apps with their names as specified in each file. Here's how I did it, for anyone who might need it in the future:

```xaml
<!-- The rest of the xmlns and other things were removed for simplicity. -->
<UserControl 
xmlns:local="clr-namespace:RetiledStart.ViewModels;assembly=RetiledStart">

<!-- ... -->
	<UserControl.Resources>
		<!-- Note: The xmlns:local thing where this is defined
		needs to be "RetiledStart.ViewModels", or it won't find
		the converter. -->
		<local:AppNameConverter x:Key="AppListItemTextConverter"/>
	</UserControl.Resources>
<!-- ... -->

<!-- The rest of the TextBlock properties were removed for simplicity. -->
<TextBlock Text="{Binding Converter={StaticResource AppListItemTextConverter}}">
<!-- ... -->
```

```csharp
// IValueConverter for the app list.
    // Ended up not using IMultiValueConverter because it just didn't
    // work as I needed it to.
    // This is from MSDN:
    // https://docs.microsoft.com/en-us/dotnet/desktop/wpf/data/?view=netdesktop-5.0#data-conversion

    public class AppNameConverter : IValueConverter
    {
        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
        {
            string DesktopEntryName = value as string;
            Debug.WriteLine(DesktopEntryName);
            Debug.WriteLine(desktopEntryStuff.getInfo(DesktopEntryName, "Name"));
            return desktopEntryStuff.getInfo(DesktopEntryName, "Name");
        }

        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
        {
            return null;
        }
    }
```