### PR TITLE
Get rid of IValueConverter.

### DIFF
--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -39,6 +39,7 @@ using Avalonia.Data.Converters;
 using libdotdesktop_standard;
 using ReactiveUI;
 using FancyStaggeredLayout.Avalonia;
+using libRetiledStart;
 
 namespace RetiledStart.ViewModels
 {
@@ -52,7 +53,7 @@ namespace RetiledStart.ViewModels
             //Console.WriteLine(desktopEntryStuff.getInfo(ExecFilename, "Exec"));
             //Debug.WriteLine(ExecFilename);
             //Debug.WriteLine(desktopEntryStuff.getInfo(ExecFilename, "Exec"));
-            libRetiledStart.AppsList.RunApp(ExecFilename);
+            AppsList.RunApp(ExecFilename);
 
         }
 
@@ -66,9 +67,9 @@ namespace RetiledStart.ViewModels
         // this code off this SO answer:
         // https://stackoverflow.com/a/64552332
 
-        private ObservableCollection<string> _GetDotDesktopFiles = new ObservableCollection<string>(libRetiledStart.AppsList.GetDotDesktopFiles());
+        private ObservableCollection<DotDesktopEntryInAllAppsList> _GetDotDesktopFiles = new ObservableCollection<DotDesktopEntryInAllAppsList>(AppsList.GetDotDesktopFiles());
 
-        public ObservableCollection<string> GetDotDesktopFiles
+        public ObservableCollection<DotDesktopEntryInAllAppsList> GetDotDesktopFiles
         {
             // Get the list of .desktop files.
             get => _GetDotDesktopFiles;
@@ -76,29 +77,5 @@ namespace RetiledStart.ViewModels
             
         }
 
-    }
-
-    // IValueConverter for the app list.
-    // Ended up not using IMultiValueConverter because it just didn't
-    // work as I needed it to.
-    // This is from MSDN:
-    // https://docs.microsoft.com/en-us/dotnet/desktop/wpf/data/?view=netdesktop-5.0#data-conversion
-
-    public class AppNameConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-        {
-            string? DesktopEntryName = value as string;
-            //Debug.WriteLine(DesktopEntryName);
-            //Debug.WriteLine(desktopEntryStuff.getInfo(DesktopEntryName, "Name"));
-            // Check if there's actually a name in the .desktop file.
-            // This is using the code in the library to make things easier.
-            return libRetiledStart.AppsList.GetDotDesktopNameKey(DesktopEntryName);
-        }
-
-        public object? ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-        {
-            return null;
-        }
     }
 }

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -32,6 +32,7 @@ respective people and companies/organizations.
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 			 xmlns:local="clr-namespace:RetiledStart.ViewModels;assembly=RetiledStart"
+			 xmlns:appslist="clr-namespace:libRetiledStart;assembly=libRetiledStart"
              mc:Ignorable="d" d:DesignWidth="360" d:DesignHeight="720"
              x:Class="RetiledStart.Views.AllAppsView">
 	<UserControl.Styles>
@@ -40,12 +41,6 @@ respective people and companies/organizations.
 		<StyleInclude Source="avares://RetiledStart/Styles/RoundButton.axaml" />
 		<StyleInclude Source="avares://RetiledStart/Styles/RoundButtonWhiteBackgroundOnPress.axaml" />
 		</UserControl.Styles>
-	<UserControl.Resources>
-		<!-- Note: The xmlns:local thing where this is defined
-		needs to be "RetiledStart.ViewModels", or it won't find
-		the converter. -->
-		<local:AppNameConverter x:Key="AppListItemTextConverter"/>
-	</UserControl.Resources>
   <Grid Margin="0" ColumnDefinitions="30,*">
 	  
 	 <StackPanel Margin="10,20,10,10">
@@ -88,11 +83,12 @@ respective people and companies/organizations.
 				  <StackLayout Spacing="0" Orientation="Vertical"/>
 			  </ItemsRepeater.Layout>
 		      <ItemsRepeater.ItemTemplate>
-				  <DataTemplate>
+				  <DataTemplate DataType="appslist:DotDesktopEntryInAllAppsList">
 					  <!-- Binding to a command in an ItemsRepeater DataTemplate requires adding
 					  "$parent[ItemsRepeater].DataContext."	before your command you want to bind to.
 					  Found this SO answer which helped: https://stackoverflow.com/a/66838883 -->
-					  <Button Command="{Binding $parent[ItemsRepeater].DataContext.RunApp}" CommandParameter="{Binding}"
+					  <Button Command="{Binding $parent[ItemsRepeater].DataContext.RunApp}" 
+							  CommandParameter="{Binding ExecKeyValueProperty}"
 							  Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" HorizontalAlignment="Stretch">
 						  <!-- HorizontalAlignment="Stretch" ensures you can click or tap on the buttons
 						  from anyware, rather than just on the text. -->
@@ -102,7 +98,7 @@ respective people and companies/organizations.
 							  https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh781198(v=win.10)?redirectedfrom=MSDN -->
 							  <TextBlock Classes="RetiledAllAppsEntry_TextBlock" 
 										 TextTrimming="CharacterEllipsis" FontSize="20"
-										 Text="{Binding Converter={StaticResource AppListItemTextConverter}}">
+										 Text="{Binding NameKeyValueProperty}">
 								  <!-- Figuring this out was a mess, but this SO answer ended
 								  up being super helpful:
 								  https://stackoverflow.com/a/39869384 -->

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -88,7 +88,7 @@ respective people and companies/organizations.
 					  "$parent[ItemsRepeater].DataContext."	before your command you want to bind to.
 					  Found this SO answer which helped: https://stackoverflow.com/a/66838883 -->
 					  <Button Command="{Binding $parent[ItemsRepeater].DataContext.RunApp}" 
-							  CommandParameter="{Binding ExecKeyValueProperty}"
+							  CommandParameter="{Binding FileNameProperty}"
 							  Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" HorizontalAlignment="Stretch">
 						  <!-- HorizontalAlignment="Stretch" ensures you can click or tap on the buttons
 						  from anyware, rather than just on the text. -->

--- a/RetiledStart/libRetiledStart/AppsList.vb
+++ b/RetiledStart/libRetiledStart/AppsList.vb
@@ -55,7 +55,7 @@ Public Class AppsList
         End Try
     End Sub
 
-    Public Shared Function GetDotDesktopFiles() As ObjectModel.ObservableCollection(Of String)
+    Public Shared Function GetDotDesktopFiles() As ObjectModel.ObservableCollection(Of DotDesktopEntryInAllAppsList)
         ' Gets all .desktop files in /usr/share/applications
         ' on Linux or my desktop on Windows.
 
@@ -69,8 +69,8 @@ Public Class AppsList
             DotDesktopFilesPath = "/usr/share/applications"
 
         ElseIf OperatingSystem.IsWindows = True Then
-            DotDesktopFilesPath = "C:\Users\Drew\Desktop"
-            'DotDesktopFilesPath = "C:\Users\drewn\Desktop"
+            'DotDesktopFilesPath = "C:\Users\Drew\Desktop"
+            DotDesktopFilesPath = "C:\Users\drewn\Desktop"
         End If
 
         For Each DotDesktopFile As String In FileIO.FileSystem.GetFiles(DotDesktopFilesPath)
@@ -79,16 +79,10 @@ Public Class AppsList
 
                 If Not desktopEntryStuff.getInfo(DotDesktopFile, "NoDisplay") = "true" Then
                     ' Make sure this .desktop file is supposed to be shown.
-                    ' Add its name if it's in the file.
-                    If desktopEntryStuff.getInfo(DotDesktopFile.ToString, "Name") IsNot Nothing Then
-                        DotDesktopFilesList.Add(New DotDesktopEntryInAllAppsList(DotDesktopFile.ToString,
-                                                                                 desktopEntryStuff.getInfo(DotDesktopFile.ToString, "Name")))
-                    Else
-                        ' It's not in the file, so add its filename.
-                        DotDesktopFilesList.Add(New DotDesktopEntryInAllAppsList(DotDesktopFile.ToString,
+                    ' Add the item.
+                    DotDesktopFilesList.Add(New DotDesktopEntryInAllAppsList(DotDesktopFile.ToString,
+                                                                                 DotDesktopFile.ToString,
                                                                                  DotDesktopFile.ToString))
-                    End If
-
                 End If
 
             End If
@@ -105,11 +99,12 @@ Public Class AppsList
         DotDesktopFilesList = DotDesktopFilesList.OrderBy(Function(x) x.NameKeyValueProperty).ToList()
 
         ' Define a new ObservableCollection that we'll use to copy the file paths into.
-        Dim NewDotDesktopFilesList As New ObjectModel.ObservableCollection(Of String)
+        Dim NewDotDesktopFilesList As New ObjectModel.ObservableCollection(Of DotDesktopEntryInAllAppsList)
 
         ' Add all of the items that are file paths to the new ObservableCollection.
         For Each Item In DotDesktopFilesList
-            NewDotDesktopFilesList.Add(Item.FileNameProperty)
+            NewDotDesktopFilesList.Add(New DotDesktopEntryInAllAppsList(Item.FileNameProperty, Item.NameKeyValueProperty,
+                                                                        Item.ExecKeyValueProperty))
         Next
 
         ' Return the collection.
@@ -148,6 +143,7 @@ Public Class DotDesktopEntryInAllAppsList
     ' Properties:
     Public Property FileNameProperty As String
     Public Property NameKeyValueProperty As String
+    Public Property ExecKeyValueProperty As String
 
     ' Required due to "Your custom class must be public and support a default (parameterless) public constructor."
     ' https://docs.microsoft.com/en-us/dotnet/desktop/wpf/advanced/xaml-and-custom-classes-for-wpf?view=netframeworkdesktop-4.8
@@ -155,11 +151,14 @@ Public Class DotDesktopEntryInAllAppsList
 
     End Sub
 
-    Public Sub New(ByVal fileName As String,
-                   ByVal nameKeyValue As String)
+    Public Sub New(fileName As String,
+                   nameKeyValue As String,
+                   execKeyValue As String)
         ' Set the properties to be the parameters.
         FileNameProperty = fileName
         NameKeyValueProperty = nameKeyValue
+        ' Add the exec key value, which is just the .desktop file.
+        ExecKeyValueProperty = execKeyValue
 
     End Sub
 

--- a/RetiledStart/libRetiledStart/AppsList.vb
+++ b/RetiledStart/libRetiledStart/AppsList.vb
@@ -83,11 +83,9 @@ Public Class AppsList
                     If Not desktopEntryStuff.getInfo(DotDesktopFile.ToString, "Name") = String.Empty Then
                         DotDesktopFilesList.Add(New DotDesktopEntryInAllAppsList(DotDesktopFile.ToString,
                                                                                      desktopEntryStuff.getInfo(
-                                                                                     DotDesktopFile.ToString, "Name"),
-                                                                                     DotDesktopFile.ToString))
+                                                                                     DotDesktopFile.ToString, "Name")))
                     Else
                         DotDesktopFilesList.Add(New DotDesktopEntryInAllAppsList(DotDesktopFile.ToString,
-                                                                                     DotDesktopFile.ToString,
                                                                                      DotDesktopFile.ToString))
                     End If
                 End If
@@ -110,8 +108,7 @@ Public Class AppsList
 
         ' Add all of the items that are file paths to the new ObservableCollection.
         For Each Item In DotDesktopFilesList
-            NewDotDesktopFilesList.Add(New DotDesktopEntryInAllAppsList(Item.FileNameProperty, Item.NameKeyValueProperty,
-                                                                        Item.ExecKeyValueProperty))
+            NewDotDesktopFilesList.Add(New DotDesktopEntryInAllAppsList(Item.FileNameProperty, Item.NameKeyValueProperty))
         Next
 
         ' Return the collection.
@@ -150,7 +147,6 @@ Public Class DotDesktopEntryInAllAppsList
     ' Properties:
     Public Property FileNameProperty As String
     Public Property NameKeyValueProperty As String
-    Public Property ExecKeyValueProperty As String
 
     ' Required due to "Your custom class must be public and support a default (parameterless) public constructor."
     ' https://docs.microsoft.com/en-us/dotnet/desktop/wpf/advanced/xaml-and-custom-classes-for-wpf?view=netframeworkdesktop-4.8
@@ -159,13 +155,10 @@ Public Class DotDesktopEntryInAllAppsList
     End Sub
 
     Public Sub New(fileName As String,
-                   nameKeyValue As String,
-                   execKeyValue As String)
+                   nameKeyValue As String)
         ' Set the properties to be the parameters.
         FileNameProperty = fileName
         NameKeyValueProperty = nameKeyValue
-        ' Add the exec key value, which is just the .desktop file.
-        ExecKeyValueProperty = execKeyValue
 
     End Sub
 

--- a/RetiledStart/libRetiledStart/AppsList.vb
+++ b/RetiledStart/libRetiledStart/AppsList.vb
@@ -79,13 +79,20 @@ Public Class AppsList
 
                 If Not desktopEntryStuff.getInfo(DotDesktopFile, "NoDisplay") = "true" Then
                     ' Make sure this .desktop file is supposed to be shown.
-                    ' Add the item.
-                    DotDesktopFilesList.Add(New DotDesktopEntryInAllAppsList(DotDesktopFile.ToString,
-                                                                                 DotDesktopFile.ToString,
-                                                                                 DotDesktopFile.ToString))
+                    ' Add the item after making sure the name exists.
+                    If Not desktopEntryStuff.getInfo(DotDesktopFile.ToString, "Name") = String.Empty Then
+                        DotDesktopFilesList.Add(New DotDesktopEntryInAllAppsList(DotDesktopFile.ToString,
+                                                                                     desktopEntryStuff.getInfo(
+                                                                                     DotDesktopFile.ToString, "Name"),
+                                                                                     DotDesktopFile.ToString))
+                    Else
+                        DotDesktopFilesList.Add(New DotDesktopEntryInAllAppsList(DotDesktopFile.ToString,
+                                                                                     DotDesktopFile.ToString,
+                                                                                     DotDesktopFile.ToString))
+                    End If
                 End If
 
-            End If
+                End If
         Next
 
         ' This is where we actually sort the list.


### PR DESCRIPTION
Since I figured out how to access multiple properties from XAML when adding tiles dynamically, I decided to get rid of the IValueConverter and just use properties for the custom All Apps list item entry type. Along with using async to get the items, this should speed up opening the All Apps list with a lot of items. I'll work on that sometime.