### PR TITLE
Add All Apps list and Tile context menu... sorta.

### DIFF
--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -57,6 +57,17 @@ namespace RetiledStart.ViewModels
 
         }
 
+        public void PutStuffInDebugger(string FilenameProperty)
+        {
+            // Send it to the other code.
+            //Console.WriteLine(ExecFilename);
+            //Console.WriteLine(desktopEntryStuff.getInfo(ExecFilename, "Exec"));
+            //Debug.WriteLine(ExecFilename);
+            //Debug.WriteLine(desktopEntryStuff.getInfo(ExecFilename, "Exec"));
+            Debug.WriteLine(FilenameProperty);
+
+        }
+
         public string GetText(string DotDesktopFilename)
         {
             // Get .desktop file text for displaying on the button.

--- a/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/AllAppsViewModel.cs
@@ -57,14 +57,24 @@ namespace RetiledStart.ViewModels
 
         }
 
-        public void PutStuffInDebugger(string FilenameProperty)
+        public void PinMediumTile(string FilenameProperty)
         {
-            // Send it to the other code.
-            //Console.WriteLine(ExecFilename);
-            //Console.WriteLine(desktopEntryStuff.getInfo(ExecFilename, "Exec"));
-            //Debug.WriteLine(ExecFilename);
-            //Debug.WriteLine(desktopEntryStuff.getInfo(ExecFilename, "Exec"));
-            Debug.WriteLine(FilenameProperty);
+            // Send the .desktop file to the more-general tile-pinning code.
+            libRetiledStart.AppsList.PinTile(FilenameProperty, "medium");
+
+        }
+
+        public void PinWideTile(string FilenameProperty)
+        {
+            // Send the .desktop file to the more-general tile-pinning code.
+            libRetiledStart.AppsList.PinTile(FilenameProperty, "wide");
+
+        }
+
+        public void PinSmallTile(string FilenameProperty)
+        {
+            // Send the .desktop file to the more-general tile-pinning code.
+            libRetiledStart.AppsList.PinTile(FilenameProperty, "small");
 
         }
 

--- a/RetiledStart/RetiledStart/ViewModels/TilesViewModel.cs
+++ b/RetiledStart/RetiledStart/ViewModels/TilesViewModel.cs
@@ -49,6 +49,34 @@ namespace RetiledStart.ViewModels
 
         }
 
+        public void UnpinTile(string FilenameProperty)
+        {
+            // Send the .desktop file to the more-general tile-unpinning code.
+            libRetiledStart.TilesList.UnpinTile(FilenameProperty);
+
+        }
+
+        public void ResizeToMediumTile(string FilenameProperty)
+        {
+            // Send the .desktop file to the more-general tile-resizing code.
+            libRetiledStart.TilesList.ResizeTile(FilenameProperty, "medium");
+
+        }
+
+        public void ResizeToWideTile(string FilenameProperty)
+        {
+            // Send the .desktop file to the more-general tile-resizing code.
+            libRetiledStart.TilesList.ResizeTile(FilenameProperty, "wide");
+
+        }
+
+        public void ResizeToSmallTile(string FilenameProperty)
+        {
+            // Send the .desktop file to the more-general tile-resizing code.
+            libRetiledStart.TilesList.ResizeTile(FilenameProperty, "small");
+
+        }
+
 
         // Couldn't figure out how to do this, so I based
         // this code off this SO answer:

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -44,7 +44,8 @@ respective people and companies/organizations.
 	<UserControl.Resources>
 		<!-- Using stuff on the UIElement.ContextRequested event from MSDN.
 		Actually, maybe this code from Avalonia will be what I'll have to use:
-		https://github.com/AvaloniaUI/Avalonia/blob/master/samples/ControlCatalog/Pages/ContextFlyoutPage.xaml.cs -->
+		https://github.com/AvaloniaUI/Avalonia/blob/master/samples/ControlCatalog/Pages/ContextFlyoutPage.xaml.cs
+		Also this, for XAML: https://github.com/AvaloniaUI/Avalonia/blob/master/samples/ControlCatalog/Pages/ContextFlyoutPage.xaml -->
 		
 		<MenuFlyout x:Key="AllAppsContextMenu">
 			<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -101,7 +101,9 @@ respective people and companies/organizations.
 									  app and prevent the user from using the MenuItems if that's the case.
 									  Not sure how to handle deep-linking tiles to make sure they're not counted
 									  as the main tile for an app.
-									  TODO 2: Figure out how to close the ContextFlyout after using an item. -->
+									  TODO 2: Figure out how to close the ContextFlyout after using an item.
+									  TODO 3: This flyout isn't accurate, but I need something. Found something that
+									  may help with the darkening: https://stackoverflow.com/questions/62194012/avalonia-ui-pop-up-overlay -->
 								    <MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (medium)" />

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -97,9 +97,15 @@ respective people and companies/organizations.
 						  <Button.ContextFlyout>
 							  <Flyout Placement="Top">
 								  <StackPanel>
-								    <MenuItem Header="pin to start (medium)" />
-									<MenuItem Header="pin to start (wide)" />
-									<MenuItem Header="pin to start (small)" />
+								    <MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PutStuffInDebugger}"
+											  CommandParameter="{Binding}"
+											  Header="pin to start (medium)" />
+									<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PutStuffInDebugger}"
+											  CommandParameter="{Binding}"
+											  Header="pin to start (wide)" />
+									<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PutStuffInDebugger}"
+											  CommandParameter="{Binding}"
+											  Header="pin to start (small)" />
 								  </StackPanel>
 							  </Flyout>
 						  </Button.ContextFlyout>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -42,7 +42,10 @@ respective people and companies/organizations.
 		<StyleInclude Source="avares://RetiledStart/Styles/RoundButtonWhiteBackgroundOnPress.axaml" />
 	</UserControl.Styles>
 	<UserControl.Resources>
-		<!-- Using stuff on the UIElement.ContextRequested event from MSDN. -->
+		<!-- Using stuff on the UIElement.ContextRequested event from MSDN.
+		Actually, maybe this code from Avalonia will be what I'll have to use:
+		https://github.com/AvaloniaUI/Avalonia/blob/master/samples/ControlCatalog/Pages/ContextMenuPage.xaml.cs -->
+		
 		<MenuFlyout x:Key="AllAppsContextMenu">
 			<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
 											  CommandParameter="{Binding FileNameProperty}"
@@ -103,7 +106,8 @@ respective people and companies/organizations.
 					  Found this SO answer which helped: https://stackoverflow.com/a/66838883 -->
 					  <Button Command="{Binding $parent[ItemsRepeater].DataContext.RunApp}" 
 							  CommandParameter="{Binding FileNameProperty}"
-							  Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" HorizontalAlignment="Stretch">
+							  Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" HorizontalAlignment="Stretch"
+							  ContextRequested="{Binding $parent[ItemsRepeater].DataContext.OpenContextMenu}">
 						  <!-- Not sure what I need for the Gestures.RightTapped to make it show the
 						  context flyout on long-press on a touchscreen in X11. Thought it should just work. 
 						  This might help:

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -117,7 +117,8 @@ respective people and companies/organizations.
 									  Actually, maybe something here might help: https://stackoverflow.com/questions/33051372/how-to-add-listbox-item-contextmenu-in-uwp 
 									  That link mentions the RightTapped event.
 									  Here's some stuff about RightTapped on MSDN: https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.uielement.righttapped?view=winui-3.0
-									  May be useful to look at this sample: https://docs.microsoft.com/en-us/samples/microsoft/windows-universal-samples/xamlcontextmenu/ -->
+									  May be useful to look at this sample: https://docs.microsoft.com/en-us/samples/microsoft/windows-universal-samples/xamlcontextmenu/ 
+									  Or maybe this one: https://docs.microsoft.com/en-us/samples/microsoft/windows-universal-samples/contextmenu/ -->
 								    <MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (medium)" />

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -89,7 +89,10 @@ respective people and companies/organizations.
 					  Found this SO answer which helped: https://stackoverflow.com/a/66838883 -->
 					  <Button Command="{Binding $parent[ItemsRepeater].DataContext.RunApp}" 
 							  CommandParameter="{Binding FileNameProperty}"
-							  Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" HorizontalAlignment="Stretch">
+							  Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" HorizontalAlignment="Stretch"
+							  Gestures.RightTapped="ContextFlyout.Show">
+						  <!-- Not sure what I need for the Gestures.RightTapped to make it show the
+						  context flyout. -->
 						  <!-- HorizontalAlignment="Stretch" ensures you can click or tap on the buttons
 						  from anyware, rather than just on the text. -->
 						  <!-- Started trying to figure out contextflyout based on this page:
@@ -110,7 +113,8 @@ respective people and companies/organizations.
 									  to put it: https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.uielement.holding?view=winrt-20348
 									  More details in Avalonia: https://github.com/AvaloniaUI/Avalonia/issues/6538
 									  Actually, maybe something here might help: https://stackoverflow.com/questions/33051372/how-to-add-listbox-item-contextmenu-in-uwp 
-									  That link mentions the RightTapped event. -->
+									  That link mentions the RightTapped event.
+									  Here's some stuff about RightTapped on MSDN: https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.uielement.righttapped?view=winrt-20348 -->
 								    <MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (medium)" />

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -95,7 +95,8 @@ respective people and companies/organizations.
 						  <!-- Started trying to figure out contextflyout based on this page:
 						  https://github.com/AvaloniaUI/Avalonia/issues/5172 -->
 						  <Button.ContextFlyout>
-							  <Flyout Placement="Top">
+							  <Flyout Placement="BottomEdgeAlignedLeft" ShowMode="Standard">
+								  <!-- Not sure if those settings do anything. -->
 								  <StackPanel>
 									  <!-- TODO: Check if there's already a tile pinned for this
 									  app and prevent the user from using the MenuItems if that's the case.
@@ -118,7 +119,7 @@ respective people and companies/organizations.
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (small)" />
 								  </StackPanel>
-							  </Flyout>
+								  </Flyout>
 						  </Button.ContextFlyout>
 						  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 							  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -40,7 +40,21 @@ respective people and companies/organizations.
 		idea of what they look like. -->
 		<StyleInclude Source="avares://RetiledStart/Styles/RoundButton.axaml" />
 		<StyleInclude Source="avares://RetiledStart/Styles/RoundButtonWhiteBackgroundOnPress.axaml" />
-		</UserControl.Styles>
+	</UserControl.Styles>
+	<UserControl.Resources>
+		<!-- Using stuff on the UIElement.ContextRequested event from MSDN. -->
+		<MenuFlyout x:Key="AllAppsContextMenu">
+			<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
+											  CommandParameter="{Binding FileNameProperty}"
+											  Header="pin to start (medium)" />
+			<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinWideTile}"
+					  CommandParameter="{Binding FileNameProperty}"
+					  Header="pin to start (wide)" />
+			<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinSmallTile}"
+					  CommandParameter="{Binding FileNameProperty}"
+					  Header="pin to start (small)" />
+		</MenuFlyout>
+	</UserControl.Resources>
   <Grid Margin="0" ColumnDefinitions="30,*">
 	  
 	 <StackPanel Margin="10,20,10,10">

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -98,13 +98,13 @@ respective people and companies/organizations.
 							  <Flyout Placement="Top">
 								  <StackPanel>
 								    <MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PutStuffInDebugger}"
-											  CommandParameter="{Binding}"
+											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (medium)" />
 									<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PutStuffInDebugger}"
-											  CommandParameter="{Binding}"
+											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (wide)" />
 									<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PutStuffInDebugger}"
-											  CommandParameter="{Binding}"
+											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (small)" />
 								  </StackPanel>
 							  </Flyout>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -103,7 +103,10 @@ respective people and companies/organizations.
 									  as the main tile for an app.
 									  TODO 2: Figure out how to close the ContextFlyout after using an item.
 									  TODO 3: This flyout isn't accurate, but I need something. Found something that
-									  may help with the darkening: https://stackoverflow.com/questions/62194012/avalonia-ui-pop-up-overlay -->
+									  may help with the darkening: https://stackoverflow.com/questions/62194012/avalonia-ui-pop-up-overlay
+									  TODO 4: I don't know how to make the menus show up on the PinePhone (and other
+									  touchscreen devices) yet. "Holding" may be useful, but I don't know where
+									  to put it: https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.uielement.holding?view=winrt-20348-->
 								    <MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (medium)" />

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -99,7 +99,9 @@ respective people and companies/organizations.
 						  from anyware, rather than just on the text. -->
 						  <!-- Started trying to figure out contextflyout based on this page:
 						  https://github.com/AvaloniaUI/Avalonia/issues/5172
-						  Here's stuff on flyouts from MSDN: https://docs.microsoft.com/en-us/windows/apps/design/controls/menus -->
+						  Here's stuff on flyouts from MSDN: https://docs.microsoft.com/en-us/windows/apps/design/controls/menus 
+						  Here's a thing on ContextFlyouts specifically on MSDN: https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.uielement.contextflyout?view=winui-3.0
+						  That link has code that changes stuff on the target item, so it should help for resizing tiles at runtime. -->
 						  <Button.ContextFlyout>
 							  <Flyout Placement="BottomEdgeAlignedLeft" ShowMode="Standard">
 								  <!-- Not sure if those settings do anything. -->

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -108,7 +108,9 @@ respective people and companies/organizations.
 									  TODO 4: I don't know how to make the menus show up on the PinePhone (and other
 									  touchscreen devices) yet. "Holding" may be useful, but I don't know where
 									  to put it: https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.uielement.holding?view=winrt-20348
-									  More details in Avalonia: https://github.com/AvaloniaUI/Avalonia/issues/6538 -->
+									  More details in Avalonia: https://github.com/AvaloniaUI/Avalonia/issues/6538
+									  Actually, maybe something here might help: https://stackoverflow.com/questions/33051372/how-to-add-listbox-item-contextmenu-in-uwp 
+									  That link mentions the RightTapped event. -->
 								    <MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (medium)" />

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -97,9 +97,9 @@ respective people and companies/organizations.
 						  <Button.ContextFlyout>
 							  <Flyout Placement="Top">
 								  <StackPanel>
-								    <TextBlock Text="pin to start (medium)" />
-									<TextBlock Text="pin to start (wide)" />
-									<TextBlock Text="pin to start (small)" />
+								    <MenuItem Header="pin to start (medium)" />
+									<MenuItem Header="pin to start (wide)" />
+									<MenuItem Header="pin to start (small)" />
 								  </StackPanel>
 							  </Flyout>
 						  </Button.ContextFlyout>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -118,7 +118,8 @@ respective people and companies/organizations.
 									  That link mentions the RightTapped event.
 									  Here's some stuff about RightTapped on MSDN: https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.uielement.righttapped?view=winui-3.0
 									  May be useful to look at this sample: https://docs.microsoft.com/en-us/samples/microsoft/windows-universal-samples/xamlcontextmenu/ 
-									  Or maybe this one: https://docs.microsoft.com/en-us/samples/microsoft/windows-universal-samples/contextmenu/ -->
+									  Or maybe this one: https://docs.microsoft.com/en-us/samples/microsoft/windows-universal-samples/contextmenu/ 
+									  Maybe this page will help: https://github.com/microsoft/Windows-universal-samples/blob/main/Samples/XamlContextMenu/shared/Scenario3.xaml -->
 								    <MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (medium)" />

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -116,7 +116,7 @@ respective people and companies/organizations.
 									  More details in Avalonia: https://github.com/AvaloniaUI/Avalonia/issues/6538
 									  Actually, maybe something here might help: https://stackoverflow.com/questions/33051372/how-to-add-listbox-item-contextmenu-in-uwp 
 									  That link mentions the RightTapped event.
-									  Here's some stuff about RightTapped on MSDN: https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.uielement.righttapped?view=winrt-20348 -->
+									  Here's some stuff about RightTapped on MSDN: https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.uielement.righttapped?view=winui-3.0 -->
 								    <MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (medium)" />

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -98,7 +98,8 @@ respective people and companies/organizations.
 						  <!-- HorizontalAlignment="Stretch" ensures you can click or tap on the buttons
 						  from anyware, rather than just on the text. -->
 						  <!-- Started trying to figure out contextflyout based on this page:
-						  https://github.com/AvaloniaUI/Avalonia/issues/5172 -->
+						  https://github.com/AvaloniaUI/Avalonia/issues/5172
+						  Here's stuff on flyouts from MSDN: https://docs.microsoft.com/en-us/windows/apps/design/controls/menus -->
 						  <Button.ContextFlyout>
 							  <Flyout Placement="BottomEdgeAlignedLeft" ShowMode="Standard">
 								  <!-- Not sure if those settings do anything. -->

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -92,6 +92,17 @@ respective people and companies/organizations.
 							  Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" HorizontalAlignment="Stretch">
 						  <!-- HorizontalAlignment="Stretch" ensures you can click or tap on the buttons
 						  from anyware, rather than just on the text. -->
+						  <!-- Started trying to figure out contextflyout based on this page:
+						  https://github.com/AvaloniaUI/Avalonia/issues/5172 -->
+						  <Button.ContextFlyout>
+							  <Flyout Placement="Top">
+								  <StackPanel>
+								    <TextBlock Text="pin to start (medium)" />
+									<TextBlock Text="pin to start (wide)" />
+									<TextBlock Text="pin to start (small)" />
+								  </StackPanel>
+							  </Flyout>
+						  </Button.ContextFlyout>
 						  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 							  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 							  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -92,7 +92,9 @@ respective people and companies/organizations.
 							  Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" HorizontalAlignment="Stretch"
 							  Gestures.RightTapped="ContextFlyout.Show">
 						  <!-- Not sure what I need for the Gestures.RightTapped to make it show the
-						  context flyout. -->
+						  context flyout. 
+						  This might help:
+						  https://github.com/AvaloniaUI/Avalonia/issues/2242 -->
 						  <!-- HorizontalAlignment="Stretch" ensures you can click or tap on the buttons
 						  from anyware, rather than just on the text. -->
 						  <!-- Started trying to figure out contextflyout based on this page:

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -44,7 +44,7 @@ respective people and companies/organizations.
 	<UserControl.Resources>
 		<!-- Using stuff on the UIElement.ContextRequested event from MSDN.
 		Actually, maybe this code from Avalonia will be what I'll have to use:
-		https://github.com/AvaloniaUI/Avalonia/blob/master/samples/ControlCatalog/Pages/ContextMenuPage.xaml.cs -->
+		https://github.com/AvaloniaUI/Avalonia/blob/master/samples/ControlCatalog/Pages/ContextFlyoutPage.xaml.cs -->
 		
 		<MenuFlyout x:Key="AllAppsContextMenu">
 			<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -115,10 +115,10 @@ respective people and companies/organizations.
 						  Here's stuff on flyouts from MSDN: https://docs.microsoft.com/en-us/windows/apps/design/controls/menus 
 						  Here's a thing on ContextFlyouts specifically on MSDN: https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.uielement.contextflyout?view=winui-3.0
 						  That link has code that changes stuff on the target item, so it should help for resizing tiles at runtime. -->
-						  <Button.ContextFlyout>
-							  <Flyout Placement="BottomEdgeAlignedLeft" ShowMode="Standard">
+						  <!--<Button.ContextFlyout>
+							  <Flyout Placement="BottomEdgeAlignedLeft" ShowMode="Standard">-->
 								  <!-- Not sure if those settings do anything. -->
-								  <StackPanel>
+								  <!--<StackPanel>-->
 									  <!-- TODO: Check if there's already a tile pinned for this
 									  app and prevent the user from using the MenuItems if that's the case.
 									  Not sure how to handle deep-linking tiles to make sure they're not counted
@@ -136,7 +136,7 @@ respective people and companies/organizations.
 									  May be useful to look at this sample: https://docs.microsoft.com/en-us/samples/microsoft/windows-universal-samples/xamlcontextmenu/ 
 									  Or maybe this one: https://docs.microsoft.com/en-us/samples/microsoft/windows-universal-samples/contextmenu/ 
 									  Maybe this page will help: https://github.com/microsoft/Windows-universal-samples/blob/main/Samples/XamlContextMenu/shared/Scenario3.xaml -->
-								    <MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
+								    <!--<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (medium)" />
 									<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinWideTile}"
@@ -146,8 +146,8 @@ respective people and companies/organizations.
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (small)" />
 								  </StackPanel>
-								  </Flyout>
-						  </Button.ContextFlyout>
+								  </Flyout>-->
+						  <!--</Button.ContextFlyout>-->
 						  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 							  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 							  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -97,6 +97,10 @@ respective people and companies/organizations.
 						  <Button.ContextFlyout>
 							  <Flyout Placement="Top">
 								  <StackPanel>
+									  <!-- TODO: Check if there's already a tile pinned for this
+									  app and prevent the user from using the MenuItems if that's the case.
+									  Not sure how to handle deep-linking tiles to make sure they're not counted
+									  as the main tile for an app. -->
 								    <MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PutStuffInDebugger}"
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (medium)" />

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -110,10 +110,10 @@ respective people and companies/organizations.
 						  Here's stuff on flyouts from MSDN: https://docs.microsoft.com/en-us/windows/apps/design/controls/menus 
 						  Here's a thing on ContextFlyouts specifically on MSDN: https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.uielement.contextflyout?view=winui-3.0
 						  That link has code that changes stuff on the target item, so it should help for resizing tiles at runtime. -->
-						  <!--<Button.ContextFlyout>
-							  <Flyout Placement="BottomEdgeAlignedLeft" ShowMode="Standard">-->
+						  <Button.ContextFlyout>
+							  <Flyout Placement="BottomEdgeAlignedLeft" ShowMode="Standard">
 								  <!-- Not sure if those settings do anything. -->
-								  <!--<StackPanel>-->
+								  <StackPanel>
 									  <!-- TODO: Check if there's already a tile pinned for this
 									  app and prevent the user from using the MenuItems if that's the case.
 									  Not sure how to handle deep-linking tiles to make sure they're not counted
@@ -131,7 +131,7 @@ respective people and companies/organizations.
 									  May be useful to look at this sample: https://docs.microsoft.com/en-us/samples/microsoft/windows-universal-samples/xamlcontextmenu/ 
 									  Or maybe this one: https://docs.microsoft.com/en-us/samples/microsoft/windows-universal-samples/contextmenu/ 
 									  Maybe this page will help: https://github.com/microsoft/Windows-universal-samples/blob/main/Samples/XamlContextMenu/shared/Scenario3.xaml -->
-								    <!--<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
+								    <MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (medium)" />
 									<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinWideTile}"
@@ -141,8 +141,8 @@ respective people and companies/organizations.
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (small)" />
 								  </StackPanel>
-								  </Flyout>-->
-						  <!--</Button.ContextFlyout>-->
+								  </Flyout>
+						  </Button.ContextFlyout>
 						  <StackPanel Height="55" Margin="0,5" Classes="RetiledAllAppsEntry_StackPanel" Orientation="Horizontal" Spacing="10">
 							  <Rectangle Classes="RetiledAllAppsEntry_Rectangle" Height="50" Width="50"/>
 							  <!-- MSDN says App List icons are 44x44 with 6x6 pixels of padding:

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -45,19 +45,10 @@ respective people and companies/organizations.
 		<!-- Using stuff on the UIElement.ContextRequested event from MSDN.
 		Actually, maybe this code from Avalonia will be what I'll have to use:
 		https://github.com/AvaloniaUI/Avalonia/blob/master/samples/ControlCatalog/Pages/ContextFlyoutPage.xaml.cs
-		Also this, for XAML: https://github.com/AvaloniaUI/Avalonia/blob/master/samples/ControlCatalog/Pages/ContextFlyoutPage.xaml -->
-		
-		<MenuFlyout x:Key="AllAppsContextMenu">
-			<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
-											  CommandParameter="{Binding FileNameProperty}"
-											  Header="pin to start (medium)" />
-			<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinWideTile}"
-					  CommandParameter="{Binding FileNameProperty}"
-					  Header="pin to start (wide)" />
-			<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinSmallTile}"
-					  CommandParameter="{Binding FileNameProperty}"
-					  Header="pin to start (small)" />
-		</MenuFlyout>
+		Also this, for XAML: https://github.com/AvaloniaUI/Avalonia/blob/master/samples/ControlCatalog/Pages/ContextFlyoutPage.xaml
+		Actually, it turns out that the code there doesn't work on the PinePhone. Either I'll have to wait until Avalonia
+		supports long-pressing to open context menus, or I'll have to go to something like QML.NET. Or I could always
+		implement the necessary code into Avalonia, but I don't know how to do it. -->
 	</UserControl.Resources>
   <Grid Margin="0" ColumnDefinitions="30,*">
 	  
@@ -107,8 +98,7 @@ respective people and companies/organizations.
 					  Found this SO answer which helped: https://stackoverflow.com/a/66838883 -->
 					  <Button Command="{Binding $parent[ItemsRepeater].DataContext.RunApp}" 
 							  CommandParameter="{Binding FileNameProperty}"
-							  Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" HorizontalAlignment="Stretch"
-							  ContextRequested="{Binding $parent[ItemsRepeater].DataContext.OpenContextMenu}">
+							  Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" HorizontalAlignment="Stretch">
 						  <!-- Not sure what I need for the Gestures.RightTapped to make it show the
 						  context flyout on long-press on a touchscreen in X11. Thought it should just work. 
 						  This might help:

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -100,7 +100,8 @@ respective people and companies/organizations.
 									  <!-- TODO: Check if there's already a tile pinned for this
 									  app and prevent the user from using the MenuItems if that's the case.
 									  Not sure how to handle deep-linking tiles to make sure they're not counted
-									  as the main tile for an app. -->
+									  as the main tile for an app.
+									  TODO 2: Figure out how to close the ContextFlyout after using an item. -->
 								    <MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (medium)" />

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -101,13 +101,13 @@ respective people and companies/organizations.
 									  app and prevent the user from using the MenuItems if that's the case.
 									  Not sure how to handle deep-linking tiles to make sure they're not counted
 									  as the main tile for an app. -->
-								    <MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PutStuffInDebugger}"
+								    <MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (medium)" />
-									<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PutStuffInDebugger}"
+									<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinWideTile}"
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (wide)" />
-									<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PutStuffInDebugger}"
+									<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinSmallTile}"
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (small)" />
 								  </StackPanel>

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -116,7 +116,8 @@ respective people and companies/organizations.
 									  More details in Avalonia: https://github.com/AvaloniaUI/Avalonia/issues/6538
 									  Actually, maybe something here might help: https://stackoverflow.com/questions/33051372/how-to-add-listbox-item-contextmenu-in-uwp 
 									  That link mentions the RightTapped event.
-									  Here's some stuff about RightTapped on MSDN: https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.uielement.righttapped?view=winui-3.0 -->
+									  Here's some stuff about RightTapped on MSDN: https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.uielement.righttapped?view=winui-3.0
+									  May be useful to look at this sample: https://docs.microsoft.com/en-us/samples/microsoft/windows-universal-samples/xamlcontextmenu/ -->
 								    <MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (medium)" />

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -106,7 +106,8 @@ respective people and companies/organizations.
 									  may help with the darkening: https://stackoverflow.com/questions/62194012/avalonia-ui-pop-up-overlay
 									  TODO 4: I don't know how to make the menus show up on the PinePhone (and other
 									  touchscreen devices) yet. "Holding" may be useful, but I don't know where
-									  to put it: https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.uielement.holding?view=winrt-20348-->
+									  to put it: https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.uielement.holding?view=winrt-20348
+									  More details in Avalonia: https://github.com/AvaloniaUI/Avalonia/issues/6538 -->
 								    <MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.PinMediumTile}"
 											  CommandParameter="{Binding FileNameProperty}"
 											  Header="pin to start (medium)" />

--- a/RetiledStart/RetiledStart/Views/AllAppsView.axaml
+++ b/RetiledStart/RetiledStart/Views/AllAppsView.axaml
@@ -89,10 +89,9 @@ respective people and companies/organizations.
 					  Found this SO answer which helped: https://stackoverflow.com/a/66838883 -->
 					  <Button Command="{Binding $parent[ItemsRepeater].DataContext.RunApp}" 
 							  CommandParameter="{Binding FileNameProperty}"
-							  Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" HorizontalAlignment="Stretch"
-							  Gestures.RightTapped="ContextFlyout.Show">
+							  Padding="0,5" Classes="RetiledAllAppsEntry_Button" Height="60" HorizontalAlignment="Stretch">
 						  <!-- Not sure what I need for the Gestures.RightTapped to make it show the
-						  context flyout. 
+						  context flyout on long-press on a touchscreen in X11. Thought it should just work. 
 						  This might help:
 						  https://github.com/AvaloniaUI/Avalonia/issues/2242 -->
 						  <!-- HorizontalAlignment="Stretch" ensures you can click or tap on the buttons

--- a/RetiledStart/RetiledStart/Views/TilesView.axaml
+++ b/RetiledStart/RetiledStart/Views/TilesView.axaml
@@ -168,16 +168,16 @@ respective people and companies/organizations.
 											<!-- TODO: Figure out a way to have tiles resize at runtime and move
 											the buttons to the corners of the tiles instead of just a context menu. -->
 											<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.UnpinTile}"
-													  CommandParameter="{Binding FileNameProperty}"
+													  CommandParameter="{Binding DotDesktopFilePath}"
 													  Header="unpin tile" />
-											<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.ResizeToWideTile}"
-													  CommandParameter="{Binding FileNameProperty}"
+											<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.ResizeToMediumTile}"
+													  CommandParameter="{Binding DotDesktopFilePath}"
 													  Header="resize tile (medium)" />
 											<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.ResizeToWideTile}"
-													  CommandParameter="{Binding FileNameProperty}"
+													  CommandParameter="{Binding DotDesktopFilePath}"
 													  Header="resize tile (wide)" />
 											<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.ResizeToSmallTile}"
-													  CommandParameter="{Binding FileNameProperty}"
+													  CommandParameter="{Binding DotDesktopFilePath}"
 													  Header="resize tile (small)" />
 										</StackPanel>
 									</Flyout>

--- a/RetiledStart/RetiledStart/Views/TilesView.axaml
+++ b/RetiledStart/RetiledStart/Views/TilesView.axaml
@@ -162,6 +162,26 @@ respective people and companies/organizations.
 										<Setter Property="Background" Value="{Binding TileColor}"/>
 									</Style>
 								</Button.Styles>
+								<Button.ContextFlyout>
+									<Flyout Placement="Top">
+										<StackPanel>
+											<!-- TODO: Figure out a way to have tiles resize at runtime and move
+											the buttons to the corners of the tiles instead of just a context menu. -->
+											<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.UnpinTile}"
+													  CommandParameter="{Binding FileNameProperty}"
+													  Header="unpin tile" />
+											<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.ResizeToWideTile}"
+													  CommandParameter="{Binding FileNameProperty}"
+													  Header="resize tile (medium)" />
+											<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.ResizeToWideTile}"
+													  CommandParameter="{Binding FileNameProperty}"
+													  Header="resize tile (wide)" />
+											<MenuItem Command="{Binding $parent[ItemsRepeater].DataContext.ResizeToSmallTile}"
+													  CommandParameter="{Binding FileNameProperty}"
+													  Header="resize tile (small)" />
+										</StackPanel>
+									</Flyout>
+								</Button.ContextFlyout>
 							</Button>
 						</DataTemplate>
 					</ItemsRepeater.ItemTemplate>

--- a/RetiledStart/libRetiledStart/AppsList.vb
+++ b/RetiledStart/libRetiledStart/AppsList.vb
@@ -85,8 +85,11 @@ Public Class AppsList
         ' Write the tile into the startlayout file so it's pinned.
         ' TODO: Implement this.
         Debug.WriteLine(".desktop file: " & FilenameProperty)
+        Console.WriteLine(".desktop file: " & FilenameProperty)
         Debug.WriteLine("Width: " & TileWidth)
+        Console.WriteLine("Width: " & TileWidth)
         Debug.WriteLine("Height: " & TileHeight)
+        Console.WriteLine("Height: " & TileHeight)
     End Sub
 
     Public Shared Function GetDotDesktopFiles() As ObjectModel.ObservableCollection(Of DotDesktopEntryInAllAppsList)

--- a/RetiledStart/libRetiledStart/AppsList.vb
+++ b/RetiledStart/libRetiledStart/AppsList.vb
@@ -55,6 +55,37 @@ Public Class AppsList
         End Try
     End Sub
 
+    Public Shared Sub PinTile(FilenameProperty As String, TileSize As String)
+        ' Based on the size of the tile, we'll set different
+        ' values in the startlayout.yaml file.
+        ' Set up variables to store width and height.
+        Dim TileWidth As Integer = 150
+        Dim TileHeight As Integer = 150
+        Select Case TileSize
+            Case "medium"
+                TileWidth = 150
+                TileHeight = 150
+            Case "wide"
+                TileWidth = 310
+                TileHeight = 150
+            Case "small"
+                TileWidth = 70
+                TileHeight = 70
+            Case Else
+                ' If there's something else passed in,
+                ' just set it to medium, which is the default.
+                TileWidth = 150
+                TileHeight = 150
+        End Select
+
+        ' Now we can start reading the startlayout.yaml file to see
+        ' whether it needs to be copied to the user's AppData (or equivalent) folder.
+        ' TODO: Implement this.
+
+        ' Write the tile into the startlayout file so it's pinned.
+        ' TODO: Implement this.
+    End Sub
+
     Public Shared Function GetDotDesktopFiles() As ObjectModel.ObservableCollection(Of DotDesktopEntryInAllAppsList)
         ' Gets all .desktop files in /usr/share/applications
         ' on Linux or my desktop on Windows.

--- a/RetiledStart/libRetiledStart/AppsList.vb
+++ b/RetiledStart/libRetiledStart/AppsList.vb
@@ -84,6 +84,9 @@ Public Class AppsList
 
         ' Write the tile into the startlayout file so it's pinned.
         ' TODO: Implement this.
+        Debug.WriteLine(".desktop file: " & FilenameProperty)
+        Debug.WriteLine("Width: " & TileWidth)
+        Debug.WriteLine("Height: " & TileHeight)
     End Sub
 
     Public Shared Function GetDotDesktopFiles() As ObjectModel.ObservableCollection(Of DotDesktopEntryInAllAppsList)

--- a/RetiledStart/libRetiledStart/TilesList.vb
+++ b/RetiledStart/libRetiledStart/TilesList.vb
@@ -31,6 +31,9 @@ Public Class TilesList
 
     Public Shared Sub UnpinTile(FilenameProperty As String)
         ' Unpin the tile based on the FilenameProperty.
+        ' I don't know how to handle the instance where there are multiple
+        ' tiles of the same .desktop file. That should only be a problem if
+        ' tiles are manually added.
 
         Debug.WriteLine(".desktop file: " & FilenameProperty)
         Console.WriteLine(".desktop file: " & FilenameProperty)

--- a/RetiledStart/libRetiledStart/TilesList.vb
+++ b/RetiledStart/libRetiledStart/TilesList.vb
@@ -29,10 +29,18 @@ Imports YamlDotNet.Serialization
 
 Public Class TilesList
 
+    Public Shared Sub UnpinTile(FilenameProperty As String)
+        ' Unpin the tile based on the FilenameProperty.
+
+        Debug.WriteLine(".desktop file: " & FilenameProperty)
+    End Sub
+
     Public Shared Sub ResizeTile(FilenameProperty As String, TileSize As String)
         ' This code may actually be able to be shared with the pinning code, but
         ' there may have to be a boolean that determines whether to edit a tile
-        ' or to pin a tile.
+        ' or to pin a tile. Actually, maybe unpinning tiles can be done in the same
+        ' block, though maybe that'll require a "TileEditMode" string to choose between
+        ' pinning, resizing, moving, or unpinning a tile. Not sure how to move tiles yet.
         ' Just pasting the code here for now as a placeholder.
 
         ' Based on the size of the tile, we'll set different

--- a/RetiledStart/libRetiledStart/TilesList.vb
+++ b/RetiledStart/libRetiledStart/TilesList.vb
@@ -29,6 +29,45 @@ Imports YamlDotNet.Serialization
 
 Public Class TilesList
 
+    Public Shared Sub ResizeTile(FilenameProperty As String, TileSize As String)
+        ' This code may actually be able to be shared with the pinning code, but
+        ' there may have to be a boolean that determines whether to edit a tile
+        ' or to pin a tile.
+        ' Just pasting the code here for now as a placeholder.
+
+        ' Based on the size of the tile, we'll set different
+        ' values in the startlayout.yaml file.
+        ' Set up variables to store width and height.
+        Dim TileWidth As Integer = 150
+        Dim TileHeight As Integer = 150
+        Select Case TileSize
+            Case "medium"
+                TileWidth = 150
+                TileHeight = 150
+            Case "wide"
+                TileWidth = 310
+                TileHeight = 150
+            Case "small"
+                TileWidth = 70
+                TileHeight = 70
+            Case Else
+                ' If there's something else passed in,
+                ' just set it to medium, which is the default.
+                TileWidth = 150
+                TileHeight = 150
+        End Select
+
+        ' Now we can start reading the startlayout.yaml file to see
+        ' whether it needs to be copied to the user's AppData (or equivalent) folder.
+        ' TODO: Implement this.
+
+        ' Write the tile data into the startlayout file so it's resized.
+        ' TODO: Implement this.
+        Debug.WriteLine(".desktop file: " & FilenameProperty)
+        Debug.WriteLine("Width: " & TileWidth)
+        Debug.WriteLine("Height: " & TileHeight)
+    End Sub
+
     Public Shared Function GetTilesList() As ObjectModel.ObservableCollection(Of StartScreenTileEntry)
         ' Gets the list of tiles that should be shown on Start.
         ' Currently has the list of tiles hardcoded.

--- a/RetiledStart/libRetiledStart/TilesList.vb
+++ b/RetiledStart/libRetiledStart/TilesList.vb
@@ -33,6 +33,7 @@ Public Class TilesList
         ' Unpin the tile based on the FilenameProperty.
 
         Debug.WriteLine(".desktop file: " & FilenameProperty)
+        Console.WriteLine(".desktop file: " & FilenameProperty)
     End Sub
 
     Public Shared Sub ResizeTile(FilenameProperty As String, TileSize As String)
@@ -72,8 +73,11 @@ Public Class TilesList
         ' Write the tile data into the startlayout file so it's resized.
         ' TODO: Implement this.
         Debug.WriteLine(".desktop file: " & FilenameProperty)
+        Console.WriteLine(".desktop file: " & FilenameProperty)
         Debug.WriteLine("Width: " & TileWidth)
+        Console.WriteLine("Width: " & TileWidth)
         Debug.WriteLine("Height: " & TileHeight)
+        Console.WriteLine("Height: " & TileHeight)
     End Sub
 
     Public Shared Function GetTilesList() As ObjectModel.ObservableCollection(Of StartScreenTileEntry)


### PR DESCRIPTION
There's an early, unfinished context menu (actually, ContextFlyout, but most people call this a "context menu") for the Tiles and items in the All Apps list, but it doesn't work on the PinePhone/on touchscreens, so I'm going to have to see if QML.NET will work instead and switch to that. Bringing this code back into main in case it'll be useful, but it's not the best.