### PR TITLE
Only show intended items in the All Apps list.

### DIFF
--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -100,7 +100,9 @@ def getDotDesktopFiles():
 		DotDesktopFilename = os.fsdecode(DotDesktopFile)
 		# Ensure only .desktop files are picked up.
 		if DotDesktopFilename.endswith( (".desktop") ):
-			DotDesktopFilesList.append(DotDesktopFilename)
+			# Make sure the .desktop file doesn't have NoDisplay = true.
+			if not desktopEntryStuff.getInfo(DotDesktopFilename, "NoDisplay", "", True) = true:
+				DotDesktopFilesList.append(DotDesktopFilename)
 	
 	# Not sure if splitting this is how to get things into the list.
 	# Wait, no it can't be split because it's a list.

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -116,7 +116,7 @@ def getDotDesktopFiles():
 	
 	# Sort the filenames.
 	# TODO: I need to figure out how to sort the filenames based on the file's "Name" key.
-	DotDesktopFilesList.sort(key=desktopEntryStuff.getInfo(DotDesktopRootPath + slash + DotDesktopFilename, "Name", DotDesktopFilename, "", True))
+	DotDesktopFilesList.sort()
 	
 	return DotDesktopFilesList
 	

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -94,6 +94,12 @@ def getDotDesktopFiles():
 	# Create empty list that will be written to later.
 	DotDesktopFilesList = []
 	
+	# Loop through the files and add them to the list.
+	for DotDesktopFile in os.listdir(FSEncodedFolder):
+		DotDesktopFilename = os.fsdecode(DotDesktopFile)
+		# Ensure only .desktop files are picked up.
+		if DotDesktopFilename.endswith( ('.desktop') )
+	
 	# Not sure if splitting this is how to get things into the list.
 	# Wait, no it can't be split because it's a list.
 	# TODO: Make sure that .desktop files are supposed to be shown in the list

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -99,9 +99,6 @@ def getDotDesktopFiles():
 	# Create empty list that will be written to later.
 	DotDesktopFilesList = []
 	
-	# Somehow I need to use a dictionary for this, and this answer seems reasonable:
-	# https://stackoverflow.com/a/31182009
-	
 	# Loop through the files and add them to the list.
 	for DotDesktopFile in os.listdir(FSEncodedFolder):
 		DotDesktopFilename = os.fsdecode(DotDesktopFile)

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -105,7 +105,7 @@ def getDotDesktopFiles():
 		# Ensure only .desktop files are picked up.
 		if DotDesktopFilename.endswith( (".desktop") ):
 			# Make sure the .desktop file doesn't have NoDisplay = true.
-			if not desktopEntryStuff.getInfo(DotDesktopRootPath + slash + DotDesktopFilename, "NoDisplay", "", True) == true:
+			if desktopEntryStuff.getInfo(DotDesktopRootPath + slash + DotDesktopFilename, "NoDisplay", "", True) == null:
 				DotDesktopFilesList.append(DotDesktopFilename)
 	
 	# Not sure if splitting this is how to get things into the list.

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -29,7 +29,7 @@ import shlex
 import subprocess
 from ..libdotdesktop_py import desktopEntryStuff
 # Stuff for getting the files from /usr/share/applications.
-from os import listdir
+import os
 from os.path import isfile, join
 
 # Python allows relative imports as used above:
@@ -81,6 +81,10 @@ def getDotDesktopFiles():
 	# https://stackoverflow.com/a/3207973
 	#DotDesktopFilesList = [file for file in listdir("C:\\Users\\drewn\Desktop") if isfile(join("C:\\Users\\drewn\Desktop", file))]
 	DotDesktopFilesList = [file for file in listdir("/usr/share/applications") if isfile(join("/usr/share/applications", file))]
+	# Only put apps in the list if they're supposed to be shown.
+	# Using the example from this answer:
+	# https://stackoverflow.com/a/51850082
+	DotDesktopRootPath = '/usr/share/applications'
 	# Not sure if splitting this is how to get things into the list.
 	# Wait, no it can't be split because it's a list.
 	# TODO: Make sure that .desktop files are supposed to be shown in the list

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -105,7 +105,7 @@ def getDotDesktopFiles():
 		# Ensure only .desktop files are picked up.
 		if DotDesktopFilename.endswith( (".desktop") ):
 			# Make sure the .desktop file doesn't have NoDisplay = true.
-			if not desktopEntryStuff.getInfo(DotDesktopRootPath + slash + DotDesktopFilename, "NoDisplay", false, "", True) == true:
+			if not desktopEntryStuff.getInfo(DotDesktopRootPath + slash + DotDesktopFilename, "NoDisplay", "false", "", True) == "true":
 				DotDesktopFilesList.append(DotDesktopFilename)
 	
 	# Not sure if splitting this is how to get things into the list.

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -89,6 +89,10 @@ def getDotDesktopFiles():
 	#DotDesktopRootPath = "C:\\Users\\drewn\Desktop"
 	DotDesktopRootPath = "/usr/share/applications"
 	
+	# Specify the type of slash.
+	slash = "/"
+	#slash = "\\"
+	
 	# Use the filesystem encode thing to get the folder.
 	FSEncodedFolder = os.fsencode(DotDesktopRootPath)
 	
@@ -101,7 +105,7 @@ def getDotDesktopFiles():
 		# Ensure only .desktop files are picked up.
 		if DotDesktopFilename.endswith( (".desktop") ):
 			# Make sure the .desktop file doesn't have NoDisplay = true.
-			if not desktopEntryStuff.getInfo(DotDesktopFilename, "NoDisplay", "", True) == true:
+			if not desktopEntryStuff.getInfo(DotDesktopRootPath + slash + DotDesktopFilename, "NoDisplay", "", True) == true:
 				DotDesktopFilesList.append(DotDesktopFilename)
 	
 	# Not sure if splitting this is how to get things into the list.

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -101,7 +101,7 @@ def getDotDesktopFiles():
 		# Ensure only .desktop files are picked up.
 		if DotDesktopFilename.endswith( (".desktop") ):
 			# Make sure the .desktop file doesn't have NoDisplay = true.
-			if not desktopEntryStuff.getInfo(DotDesktopFilename, "NoDisplay", "", True) = true:
+			if not desktopEntryStuff.getInfo(DotDesktopFilename, "NoDisplay", "", True) == true:
 				DotDesktopFilesList.append(DotDesktopFilename)
 	
 	# Not sure if splitting this is how to get things into the list.

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -86,7 +86,8 @@ def getDotDesktopFiles():
 	# https://stackoverflow.com/a/51850082
 	
 	# Specify root path.
-	DotDesktopRootPath = '/usr/share/applications'
+	#DotDesktopRootPath = "C:\\Users\\drewn\Desktop"
+	DotDesktopRootPath = "/usr/share/applications"
 	
 	# Use the filesystem encode thing to get the folder.
 	FSEncodedFolder = os.fsencode(DotDesktopRootPath)
@@ -98,7 +99,7 @@ def getDotDesktopFiles():
 	for DotDesktopFile in os.listdir(FSEncodedFolder):
 		DotDesktopFilename = os.fsdecode(DotDesktopFile)
 		# Ensure only .desktop files are picked up.
-		if DotDesktopFilename.endswith( ('.desktop') )
+		if DotDesktopFilename.endswith( (".desktop") ):
 			DotDesktopFilesList.append(DotDesktopFilename)
 	
 	# Not sure if splitting this is how to get things into the list.

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -99,6 +99,9 @@ def getDotDesktopFiles():
 	# Create empty list that will be written to later.
 	DotDesktopFilesList = []
 	
+	# Somehow I need to use a dictionary for this, and this answer seems reasonable:
+	# https://stackoverflow.com/a/31182009
+	
 	# Loop through the files and add them to the list.
 	for DotDesktopFile in os.listdir(FSEncodedFolder):
 		DotDesktopFilename = os.fsdecode(DotDesktopFile)
@@ -113,6 +116,15 @@ def getDotDesktopFiles():
 	# TODO: Make sure that .desktop files are supposed to be shown in the list
 	# before adding them.
 	#print(DotDesktopFilesList)
+	
+	# Now we make the .desktop file thing into a dictionary:
+	# https://stackoverflow.com/a/31182009
+	# There has to be a more efficient way to do this.
+	# Define the dictionary.
+	DotDesktopDictionary = []
+	for DotDesktopFileEntry in DotDesktopFilesList:
+		DotDesktopDictionaryEntry = {"FileNameProperty": DotDesktopFileEntry, "NameKeyValueProperty": desktopEntryStuff.getInfo(DotDesktopRootPath + slash + DotDesktopFilename, "Name", DotDesktopFileEntry, "", True)}
+		DotDesktopDictionary.append(DotDesktopDictionaryEntry)
 	
 	# Sort the filenames.
 	# TODO: I need to figure out how to sort the filenames based on the file's "Name" key.

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -99,12 +99,18 @@ def getDotDesktopFiles():
 		DotDesktopFilename = os.fsdecode(DotDesktopFile)
 		# Ensure only .desktop files are picked up.
 		if DotDesktopFilename.endswith( ('.desktop') )
+			DotDesktopFilesList.append(DotDesktopFilename)
 	
 	# Not sure if splitting this is how to get things into the list.
 	# Wait, no it can't be split because it's a list.
 	# TODO: Make sure that .desktop files are supposed to be shown in the list
 	# before adding them.
 	#print(DotDesktopFilesList)
+	
+	# Sort the filenames.
+	# TODO: I need to figure out how to sort the filenames based on the file's "Name" key.
+	DotDesktopFilesList.sort()
+	
 	return DotDesktopFilesList
 	
 	

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -125,12 +125,15 @@ def getDotDesktopFiles():
 	
 	# Sort the filenames.
 	# TODO: I need to figure out how to sort the filenames based on the file's "Name" key.
-	DotDesktopFilesList.sort()
+	DotDesktopDictionary.sort(key=getKeyForSorting)
 	
 	return DotDesktopFilesList
 	
 	
-	
+def getKeyForSorting(key):
+	# Example from here:
+	# https://www.w3schools.com/python/ref_list_sort.asp
+	return key["NameKeyValueProperty"]
 	
 	
 	

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -50,7 +50,7 @@ from os.path import isfile, join
 # the code can be cleaner.
 def RunApp(DotDesktopFilePath):
         # Get the ExecFilename split using shlex.split.
-	args = desktopEntryStuff.getInfo(DotDesktopFilePath, "Exec", "", True)
+	args = desktopEntryStuff.getInfo(DotDesktopFilePath, "Exec", "", "", True)
 	splitargs = shlex.split(args)
 		# Now run the command.
 		# TODO: Ensure the command is wrapped in quotes
@@ -63,7 +63,7 @@ def RunApp(DotDesktopFilePath):
 
 def GetAppName(DotDesktopFilePath):
 	# Gets the app's name using the libdotdesktop_py library.
-	return desktopEntryStuff.getInfo(DotDesktopFilePath, "Name", "", True)
+	return desktopEntryStuff.getInfo(DotDesktopFilePath, "Name", DotDesktopFilePath, "", True)
 	
 def getDotDesktopFiles():
 	# Gets the list of .desktop files and creates a list of objects
@@ -105,7 +105,7 @@ def getDotDesktopFiles():
 		# Ensure only .desktop files are picked up.
 		if DotDesktopFilename.endswith( (".desktop") ):
 			# Make sure the .desktop file doesn't have NoDisplay = true.
-			if desktopEntryStuff.getInfo(DotDesktopRootPath + slash + DotDesktopFilename, "NoDisplay", "", True) == null:
+			if not desktopEntryStuff.getInfo(DotDesktopRootPath + slash + DotDesktopFilename, "NoDisplay", false, "", True) == true:
 				DotDesktopFilesList.append(DotDesktopFilename)
 	
 	# Not sure if splitting this is how to get things into the list.

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -80,11 +80,20 @@ def getDotDesktopFiles():
 	# Get the list of files from /usr/share/applications:
 	# https://stackoverflow.com/a/3207973
 	#DotDesktopFilesList = [file for file in listdir("C:\\Users\\drewn\Desktop") if isfile(join("C:\\Users\\drewn\Desktop", file))]
-	DotDesktopFilesList = [file for file in listdir("/usr/share/applications") if isfile(join("/usr/share/applications", file))]
+	#DotDesktopFilesList = [file for file in listdir("/usr/share/applications") if isfile(join("/usr/share/applications", file))]
 	# Only put apps in the list if they're supposed to be shown.
 	# Using the example from this answer:
 	# https://stackoverflow.com/a/51850082
+	
+	# Specify root path.
 	DotDesktopRootPath = '/usr/share/applications'
+	
+	# Use the filesystem encode thing to get the folder.
+	FSEncodedFolder = os.fsencode(DotDesktopRootPath)
+	
+	# Create empty list that will be written to later.
+	DotDesktopFilesList = []
+	
 	# Not sure if splitting this is how to get things into the list.
 	# Wait, no it can't be split because it's a list.
 	# TODO: Make sure that .desktop files are supposed to be shown in the list

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -118,30 +118,31 @@ def getDotDesktopFiles():
 	# https://stackoverflow.com/a/31182009
 	# There has to be a more efficient way to do this.
 	# Define the dictionary.
-	DotDesktopDictionary = []
-	for DotDesktopFileEntry in DotDesktopFilesList:
-		DotDesktopDictionaryEntry = {"FileNameProperty": DotDesktopFileEntry, "NameKeyValueProperty": desktopEntryStuff.getInfo(DotDesktopRootPath + slash + DotDesktopFilename, "Name", DotDesktopFileEntry, "", True)}
-		DotDesktopDictionary.append(DotDesktopDictionaryEntry)
+	#DotDesktopDictionary = []
+	#for DotDesktopFileEntry in DotDesktopFilesList:
+	#	DotDesktopDictionary[DotDesktopFileEntry] = {"FileNameProperty": DotDesktopFileEntry, "NameKeyValueProperty": desktopEntryStuff.getInfo(DotDesktopRootPath + slash + DotDesktopFilename, "Name", DotDesktopFileEntry, "", True)}
+	#	DotDesktopDictionary.append(DotDesktopDictionaryEntry)
 	
 	# Sort the filenames.
 	# TODO: I need to figure out how to sort the filenames based on the file's "Name" key.
-	DotDesktopDictionary.sort(key=getKeyForSorting)
+	DotDesktopFilesList.sort()
+	#DotDesktopDictionary.sort(key=getKeyForSorting)
 	
 	# Put it back into a list because I don't know how to
 	# use dictionaries with QML listview models yet.
 	# Example here:
 	# https://pythonexamples.org/python-dictionary-values-to-list/#4
-	SortedDotDesktopFilesList = []
-	for FilenameKey in DotDesktopDictionary:
-		SortedDotDesktopFilesList.append(DotDesktopDictionary[FileNameProperty])
+	#SortedDotDesktopFilesList = []
+	#for FilenameKey in DotDesktopDictionary:
+	#	SortedDotDesktopFilesList.append(DotDesktopDictionary[FileNameProperty])
 	
-	return SortedDotDesktopFilesList
+	return DotDesktopFilesList
 	
 	
-def getKeyForSorting(key):
+#def getKeyForSorting(key):
 	# Example from here:
 	# https://www.w3schools.com/python/ref_list_sort.asp
-	return key["NameKeyValueProperty"]
+#	return key["NameKeyValueProperty"]
 	
 	
 	

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -127,7 +127,15 @@ def getDotDesktopFiles():
 	# TODO: I need to figure out how to sort the filenames based on the file's "Name" key.
 	DotDesktopDictionary.sort(key=getKeyForSorting)
 	
-	return DotDesktopFilesList
+	# Put it back into a list because I don't know how to
+	# use dictionaries with QML listview models yet.
+	# Example here:
+	# https://pythonexamples.org/python-dictionary-values-to-list/#4
+	SortedDotDesktopFilesList = []
+	for FilenameKey in DotDesktopDictionary:
+		SortedDotDesktopFilesList.append(DotDesktopDictionary[FileNameProperty])
+	
+	return SortedDotDesktopFilesList
 	
 	
 def getKeyForSorting(key):

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -116,7 +116,7 @@ def getDotDesktopFiles():
 	
 	# Sort the filenames.
 	# TODO: I need to figure out how to sort the filenames based on the file's "Name" key.
-	DotDesktopFilesList.sort()
+	DotDesktopFilesList.sort(key=desktopEntryStuff.getInfo(DotDesktopRootPath + slash + DotDesktopFilename, "Name", DotDesktopFilename, "", True))
 	
 	return DotDesktopFilesList
 	

--- a/RetiledStart/PyRetiledStart/libs/libdotdesktop_py/desktopEntryStuff.py
+++ b/RetiledStart/PyRetiledStart/libs/libdotdesktop_py/desktopEntryStuff.py
@@ -24,7 +24,7 @@
 
 import configparser
 
-def getInfo(inputFile, keyToGet, fileName = "", IsCustomKey = False):
+def getInfo(inputFile, keyToGet, defaultValue, fileName = "", IsCustomKey = False):
 	# fileName and IsCustomKey are both optional.
 	
 	# Create a configparser to read the .desktop files.
@@ -69,5 +69,10 @@ def getInfo(inputFile, keyToGet, fileName = "", IsCustomKey = False):
 		# Return the value of the key specified in keyToGet.
 		# This works, I just have to remember to set IsCustomKey = True
 		# for anything I haven't implemented yet.
-		return dotDesktopFileReader.get('Desktop Entry', keyToGet)
-		
+		# Make sure the key is in the file and return the default
+		# if it's not:
+		# https://stackoverflow.com/a/21057828
+		if dotDesktopFileReader.has_option('Desktop Entry', keyToGet):		
+			return dotDesktopFileReader.get('Desktop Entry', keyToGet)
+		else:
+			return defaultValue

--- a/RetiledStart/PyRetiledStart/main.py
+++ b/RetiledStart/PyRetiledStart/main.py
@@ -46,7 +46,8 @@ class AllAppsListViewModel(QObject):
 	def RunApp(self, ViewModelExecFilename):
 		# Pass the app's command to the code to actually
 		# figure out how to run it.
-		AppsList.RunApp(ViewModelExecFilename)
+		#AppsList.RunApp("C:\\Users\\drewn\\Desktop\\" + ViewModelExecFilename)
+		AppsList.RunApp("/usr/share/applications/" + ViewModelExecFilename)
 		#AppsList.GetAppName(ViewModelExecFilename)
 	
 	# Slots still need to exist when using PySide.
@@ -62,7 +63,8 @@ class AllAppsListViewModel(QObject):
 	# https://stackoverflow.com/a/36210838
 	def GetDesktopEntryNameKey(self, DotDesktopFile):
 		# Get and return the .desktop file's Name key value.
-		return AppsList.GetAppName(DotDesktopFile)
+		#return AppsList.GetAppName("C:\\Users\\drewn\\Desktop\\" + DotDesktopFile)
+		return AppsList.GetAppName("/usr/share/applications/" + DotDesktopFile)
 		
 # This class is for the items in the All Apps list as described in
 # the second half of this answer:

--- a/RetiledStart/PyRetiledStart/pages/AllApps.qml
+++ b/RetiledStart/PyRetiledStart/pages/AllApps.qml
@@ -132,11 +132,11 @@ import "../../../RetiledStyles" as RetiledStyles
 			model: allAppsListItems.model
 			delegate: Column { RetiledStyles.AllAppsListEntry { 
 								//entryText: model.display
-								entryText: allAppsListViewModel.GetDesktopEntryNameKey("/usr/share/applications/" + model.display)
+								entryText: allAppsListViewModel.GetDesktopEntryNameKey(model.display)
 								//entryText: allAppsListViewModel.GetDesktopEntryNameKey("/usr/share/applications/" + name)
 								// Width of the window - 50 ends up with buttons that fill the width like they're supposed to.
 								width: window.width - 50
-								onClicked: allAppsListViewModel.RunApp("/usr/share/applications/" + model.display)
+								onClicked: allAppsListViewModel.RunApp(model.display)
 								//onClicked: allAppsListViewModel.RunApp("/usr/share/applications/" + dotDesktopFile)
 								} // End of the Button delegate item in the listview.
 			} // End of the Column that's the ListView's delegate.


### PR DESCRIPTION
Now, only .desktop files that don't have `NoDisplay = true` are shown. The All Apps list is now also being sorted by .desktop filenames, though it's intended to be sorted by the `Name` key, but I can't figure that out at the moment. Folder paths have also been moved to the Python code from the QML files so debugging and porting is easier.