### PR TITLE
Basic Start screen context menus.

### DIFF
--- a/RetiledStart/PyRetiledStart/main.py
+++ b/RetiledStart/PyRetiledStart/main.py
@@ -125,6 +125,12 @@ class TilesListViewModel(QObject):
 		else:
 			#AppsList.RunApp("/usr/share/applications/" + ViewModelExecFilename)
 			AppsList.RunApp(ViewModelExecFilename)
+			
+	# Unpin tile.
+	@Slot(str)
+	def UnpinTile(self, dotDesktopFilePath):
+		# Unpins the tile by passing it to the code-behind.
+		print(dotDesktopFilePath)
 		
 	# Slots still need to exist when using PySide.
 	@Slot(result=str)

--- a/RetiledStart/PyRetiledStart/main.py
+++ b/RetiledStart/PyRetiledStart/main.py
@@ -132,6 +132,15 @@ class TilesListViewModel(QObject):
 		# Unpins the tile by passing it to the code-behind.
 		print(dotDesktopFilePath)
 		
+	# Resize tile.
+	# Remember to add arguments for each item into the @Slot().
+	@Slot(str, int, int)
+	def ResizeTile(self, dotDesktopFilePath, newTileWidth, newTileHeight):
+		# Resizes the tile by passing it to the code-behind.
+		print(dotDesktopFilePath)
+		print(newTileWidth)
+		print(newTileHeight)
+		
 	# Slots still need to exist when using PySide.
 	@Slot(result=str)
 	def getTilesList(self):

--- a/RetiledStart/PyRetiledStart/main.py
+++ b/RetiledStart/PyRetiledStart/main.py
@@ -75,6 +75,11 @@ class AllAppsListViewModel(QObject):
 			return AppsList.GetAppName("C:\\Users\\drewn\\Desktop\\" + DotDesktopFile)
 		else:
 			return AppsList.GetAppName("/usr/share/applications/" + DotDesktopFile)
+	
+	# Pin the app to Start.
+	@Slot(str)
+	def PinToStart(self, dotDesktopFilePath):
+		print(dotDesktopFilePath)
 		
 # This class is for the items in the All Apps list as described in
 # the second half of this answer:

--- a/RetiledStart/PyRetiledStart/pages/AllApps.qml
+++ b/RetiledStart/PyRetiledStart/pages/AllApps.qml
@@ -139,12 +139,16 @@ import "../../../RetiledStyles" as RetiledStyles
 								onClicked: allAppsListViewModel.RunApp(model.display)
 								// Set pin to start stuff.
 								dotDesktopFilePath: model.display
-								pinToStart.connect(pinToStart)
+								onPinToStart: pinToStart(model.display)
 								//onClicked: allAppsListViewModel.RunApp("/usr/share/applications/" + dotDesktopFile)
 								} // End of the Button delegate item in the listview.
 			} // End of the Column that's the ListView's delegate.
 			} // End of the ListView that holds the app entries for the All Apps list.
 			
+			// Function for pinning the app to start.
+			function pinToStart(dotDesktopFilePath) {
+					allAppsListViewModel.PinToStart(dotDesktopFilePath);
+				}
 			
 		} // End of the All Apps list flickable.
 		

--- a/RetiledStart/PyRetiledStart/pages/AllApps.qml
+++ b/RetiledStart/PyRetiledStart/pages/AllApps.qml
@@ -98,6 +98,7 @@ import "../../../RetiledStyles" as RetiledStyles
 			
 			
 			
+			
 			ListView {
                 
 				width: window.width
@@ -139,17 +140,13 @@ import "../../../RetiledStyles" as RetiledStyles
 								onClicked: allAppsListViewModel.RunApp(model.display)
 								// Set pin to start stuff.
 								dotDesktopFilePath: model.display
-								onPinToStart: pinToStart(model.display)
+								onPinToStart: allAppsListViewModel.PinToStart(model.display)
 								//onClicked: allAppsListViewModel.RunApp("/usr/share/applications/" + dotDesktopFile)
 								} // End of the Button delegate item in the listview.
 			} // End of the Column that's the ListView's delegate.
 			} // End of the ListView that holds the app entries for the All Apps list.
 			
-			// Function for pinning the app to start.
-			function pinToStart(dotDesktopFilePath) {
-					// allAppsListViewModel.PinToStart(dotDesktopFilePath);
-					console.log("ggrg");
-				}
+			
 			
 		} // End of the All Apps list flickable.
 		

--- a/RetiledStart/PyRetiledStart/pages/AllApps.qml
+++ b/RetiledStart/PyRetiledStart/pages/AllApps.qml
@@ -98,7 +98,6 @@ import "../../../RetiledStyles" as RetiledStyles
 			
 			
 			
-			
 			ListView {
                 
 				width: window.width

--- a/RetiledStart/PyRetiledStart/pages/AllApps.qml
+++ b/RetiledStart/PyRetiledStart/pages/AllApps.qml
@@ -137,6 +137,9 @@ import "../../../RetiledStyles" as RetiledStyles
 								// Width of the window - 50 ends up with buttons that fill the width like they're supposed to.
 								width: window.width - 50
 								onClicked: allAppsListViewModel.RunApp(model.display)
+								// Set pin to start stuff.
+								dotDesktopFilePath: model.display
+								pinToStart.connect(pinToStart)
 								//onClicked: allAppsListViewModel.RunApp("/usr/share/applications/" + dotDesktopFile)
 								} // End of the Button delegate item in the listview.
 			} // End of the Column that's the ListView's delegate.

--- a/RetiledStart/PyRetiledStart/pages/AllApps.qml
+++ b/RetiledStart/PyRetiledStart/pages/AllApps.qml
@@ -146,7 +146,6 @@ import "../../../RetiledStyles" as RetiledStyles
 			} // End of the ListView that holds the app entries for the All Apps list.
 			
 			
-			
 		} // End of the All Apps list flickable.
 		
 			} // End of the All Apps list ColumnLayout, not to be confused with the one inside the Flickable.

--- a/RetiledStart/PyRetiledStart/pages/AllApps.qml
+++ b/RetiledStart/PyRetiledStart/pages/AllApps.qml
@@ -147,7 +147,8 @@ import "../../../RetiledStyles" as RetiledStyles
 			
 			// Function for pinning the app to start.
 			function pinToStart(dotDesktopFilePath) {
-					allAppsListViewModel.PinToStart(dotDesktopFilePath);
+					// allAppsListViewModel.PinToStart(dotDesktopFilePath);
+					console.log("ggrg");
 				}
 			
 		} // End of the All Apps list flickable.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -182,8 +182,9 @@ ApplicationWindow {
 				}
 				
 				// Set up the long-press signal.
-				function tileLongPressed(showContextMenu) {
-					showContextMenu = true;
+				function tileLongPressed() {
+					//showContextMenu = true;
+					console.log("long-pressed");
 					// TODO: There needs to be a way to set it
 					// back to false after closing it.
 				}
@@ -233,33 +234,33 @@ ApplicationWindow {
 						// Make sure it's ready first.
 						// TODO: Switch to incubateObject.
 						//if (TileComponent.status == Component.Ready) {
-						var NewTileObect = TileComponent.createObject(tilesContainer);
+						var NewTileObject = TileComponent.createObject(tilesContainer);
 						// Set tile properties.
-						NewTileObect.tileText = ParsedTilesList[i].TileAppNameAreaText;
-						NewTileObect.width = ParsedTilesList[i].TileWidth;
-						NewTileObect.height = ParsedTilesList[i].TileHeight;
-						NewTileObect.tileBackgroundColor = ParsedTilesList[i].TileColor;
+						NewTileObject.tileText = ParsedTilesList[i].TileAppNameAreaText;
+						NewTileObject.width = ParsedTilesList[i].TileWidth;
+						NewTileObject.height = ParsedTilesList[i].TileHeight;
+						NewTileObject.tileBackgroundColor = ParsedTilesList[i].TileColor;
 						// Doesn't quite work on Windows because the hardcoded tile is trying to read
 						// from /usr/share/applications and can't find Firefox.
 						// Turns out it was trying to run Firefox. Not sure how to stop that.
 						// Actually, I think this involves an event handler:
 						// https://stackoverflow.com/a/22605752
-						NewTileObect.execKey = ParsedTilesList[i].DotDesktopPath;
+						NewTileObject.execKey = ParsedTilesList[i].DotDesktopPath;
 						
 						// Set the .desktop file path for unpinning or resizing.
-						NewTileObect.dotDesktopFilePath = ParsedTilesList[i].DotDesktopPath;
+						NewTileObject.dotDesktopFilePath = ParsedTilesList[i].DotDesktopPath;
 												
 						// Connect clicked signal.
-						NewTileObect.clicked.connect(tileClicked);
+						NewTileObject.clicked.connect(tileClicked);
 						
 						// Connect long-press signal.
 						NewTileObject.pressAndHold.connect(tileLongPressed);
 						
 						// Connect unpin signal.
-						NewTileObect.unpinTile.connect(unpinTile);
+						NewTileObject.unpinTile.connect(unpinTile);
 						
 						// Connect resize signal.
-						NewTileObect.resizeTile.connect(resizeTile);
+						NewTileObject.resizeTile.connect(resizeTile);
 						
 						//} // End of If statement to ensure things are ready.
 						

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -182,7 +182,7 @@ ApplicationWindow {
 				}
 				
 				// Set up the long-press signal.
-				function tileLongPressed() {
+				function tileLongPressed(showContextMenu) {
 					//showContextMenu = true;
 					console.log("long-pressed");
 					// TODO: There needs to be a way to set it

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -181,14 +181,6 @@ ApplicationWindow {
 					tilesListViewModel.RunApp(execKey);
 				}
 				
-				// Set up the long-press signal.
-				function tileLongPressed(showContextMenu) {
-					showContextMenu = true;
-					console.log(showContextMenu);
-					// TODO: There needs to be a way to set it
-					// back to false after closing it.
-				}
-				
 				// Set up the signals for the tile context menu.
 				// Unpin tiles.
 				function unpinTile(dotDesktopFilePath) {
@@ -254,7 +246,7 @@ ApplicationWindow {
 						NewTileObject.clicked.connect(tileClicked);
 						
 						// Connect long-press signal.
-						NewTileObject.pressAndHold.connect(tileLongPressed);
+						// NewTileObject.pressAndHold.connect(tileLongPressed);
 						
 						// Connect unpin signal.
 						NewTileObject.unpinTile.connect(unpinTile);

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -316,7 +316,7 @@ ApplicationWindow {
 		} // End of ColumnLayout for the tiles and All Apps button.
 		
 		Item {
-				// Empty item that acts as a margin on the left of the
+				// Empty item that acts as a margin on the right of the
 				// tiles so it can be scrolled, as margins don't allow scrolling.
 				width: 10
 			}

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -183,8 +183,8 @@ ApplicationWindow {
 				
 				// Set up the long-press signal.
 				function tileLongPressed(showContextMenu) {
-					//showContextMenu = true;
-					console.log("long-pressed");
+					showContextMenu = true;
+					console.log(showContextMenu);
 					// TODO: There needs to be a way to set it
 					// back to false after closing it.
 				}

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -181,6 +181,13 @@ ApplicationWindow {
 					tilesListViewModel.RunApp(execKey);
 				}
 				
+				// Set up the long-press signal.
+				function tileLongPressed(tilemenu) {
+					tilemenu.open();
+				}
+				
+				// dotDesktopFilePath, newTileWidth, newTileHeight
+				
 				Component.onCompleted: {
 					
 					// Start looping through the list provided by Python
@@ -231,6 +238,9 @@ ApplicationWindow {
 												
 						// Connect clicked signal.
 						NewTileObect.clicked.connect(tileClicked);
+						
+						// Connect long-press signal.
+						NewTileObject.pressAndHold.connect(tileLongPressed);
 						
 						} // End of If statement to ensure things are ready.
 						

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -182,8 +182,10 @@ ApplicationWindow {
 				}
 				
 				// Set up the long-press signal.
-				function tileLongPressed(tilemenu) {
-					tilemenu.open();
+				function tileLongPressed(showContextMenu) {
+					showContextMenu = true;
+					// TODO: There needs to be a way to set it
+					// back to false after closing it.
 				}
 				
 				// Set up the signals for the tile context menu.
@@ -230,7 +232,7 @@ ApplicationWindow {
 						// Now create the tile.
 						// Make sure it's ready first.
 						// TODO: Switch to incubateObject.
-						if (TileComponent.status == Component.Ready) {
+						//if (TileComponent.status == Component.Ready) {
 						var NewTileObect = TileComponent.createObject(tilesContainer);
 						// Set tile properties.
 						NewTileObect.tileText = ParsedTilesList[i].TileAppNameAreaText;
@@ -259,7 +261,7 @@ ApplicationWindow {
 						// Connect resize signal.
 						NewTileObect.resizeTile.connect(resizeTile);
 						
-						} // End of If statement to ensure things are ready.
+						//} // End of If statement to ensure things are ready.
 						
 					} // End of For loop that loads the tiles.
 					

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -186,7 +186,15 @@ ApplicationWindow {
 					tilemenu.open();
 				}
 				
-				// dotDesktopFilePath, newTileWidth, newTileHeight
+				// Set up the signals for the tile context menu.
+				// Unpin tiles.
+				function unpinTile(dotDesktopFilePath) {
+					tilesListViewModel.UnpinTile(dotDesktopFilePath);
+				}
+				// Resize tiles.
+				function resizeTile(dotDesktopFilePath, newTileWidth, newTileHeight) {
+					tilesListViewModel.ResizeTile(dotDesktopFilePath, newTileWidth, newTileHeight);
+				}
 				
 				Component.onCompleted: {
 					

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -250,6 +250,12 @@ ApplicationWindow {
 						// Connect long-press signal.
 						NewTileObject.pressAndHold.connect(tileLongPressed);
 						
+						// Connect unpin signal.
+						NewTileObect.unpinTile.connect(unpinTile);
+						
+						// Connect resize signal.
+						NewTileObect.resizeTile.connect(resizeTile);
+						
 						} // End of If statement to ensure things are ready.
 						
 					} // End of For loop that loads the tiles.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -243,6 +243,9 @@ ApplicationWindow {
 						// Actually, I think this involves an event handler:
 						// https://stackoverflow.com/a/22605752
 						NewTileObect.execKey = ParsedTilesList[i].DotDesktopPath;
+						
+						// Set the .desktop file path for unpinning or resizing.
+						NewTileObect.dotDesktopFilePath = ParsedTilesList[i].DotDesktopPath;
 												
 						// Connect clicked signal.
 						NewTileObect.clicked.connect(tileClicked);

--- a/RetiledStyles/AllAppsListEntry.qml
+++ b/RetiledStyles/AllAppsListEntry.qml
@@ -39,6 +39,7 @@ RetiledStyles.Button {
 	
 	// Set button height.
 	buttonHeight: 60
+	buttonWidth: parent.width
 	
 	// Set text size.
 	fontSize: 20
@@ -66,6 +67,22 @@ RetiledStyles.Button {
 	
 	// Open the context menu.
 	onPressAndHold: allappscontextmenu.open()
+	
+	
+	// Adding the context menus:
+	// https://doc.qt.io/qt-6/qml-qtquick-controls2-popup.html
+	Popup {
+		id: allappscontextmenu
+		anchors.centerIn: parent
+		contentWidth: window.width
+		// We're using the column layout.
+		Column {
+			anchors.fill: parent
+			ButtonBase {
+				text: qsTr("pin to start")
+			}
+		}
+	}
 	
 	Row {
 		// Fill the button so we can align things properly.
@@ -103,18 +120,6 @@ RetiledStyles.Button {
 	
 	} // End of the row for the button and text.
 	
-	// Adding the context menus:
-	// https://doc.qt.io/qt-6/qml-qtquick-controls2-popup.html
-	Popup {
-		id: allappscontextmenu
-		// We're using the column layout.
-		Column {
-			anchors.fill: parent
-			ButtonBase {
-				text: qsTr("pin to start")
-			}
-		}
-	}
 	
 } // End of the ButtonBase containing the All Apps list button item.
 

--- a/RetiledStyles/AllAppsListEntry.qml
+++ b/RetiledStyles/AllAppsListEntry.qml
@@ -81,7 +81,9 @@ RetiledStyles.Button {
 		modal: true
 		// Center the popup in the window:
 		// https://stackoverflow.com/a/45052225
-		x: (width) / 2
+		// We have to divide by -2 or it goes
+		// off the right side of the screen.
+		x: (width) / -2
 		// We're using the column layout.
 		Column {
 			anchors.fill: parent

--- a/RetiledStyles/AllAppsListEntry.qml
+++ b/RetiledStyles/AllAppsListEntry.qml
@@ -71,10 +71,17 @@ RetiledStyles.Button {
 	
 	// Adding the context menus:
 	// https://doc.qt.io/qt-6/qml-qtquick-controls2-popup.html
+	// Here's how to do it dynamically, which might help with
+	// the tiles:
+	// https://stackoverflow.com/a/45052339
 	Popup {
 		id: allappscontextmenu
 		width: window.width
 		contentWidth: window.width
+		modal: true
+		// Center the popup in the window:
+		// https://stackoverflow.com/a/45052225
+		x: (width) / 2
 		// We're using the column layout.
 		Column {
 			anchors.fill: parent

--- a/RetiledStyles/AllAppsListEntry.qml
+++ b/RetiledStyles/AllAppsListEntry.qml
@@ -93,7 +93,7 @@ RetiledStyles.Button {
 			ButtonBase {
 				width: parent.width
 				text: qsTr("pin to start")
-				onClicked: parent.pinToStart(parent.dotDesktopFilePath)
+				onClicked: pinToStart(dotDesktopFilePath)
 			}
 		}
 	}

--- a/RetiledStyles/AllAppsListEntry.qml
+++ b/RetiledStyles/AllAppsListEntry.qml
@@ -87,6 +87,14 @@ RetiledStyles.Button {
 		// We have to divide by -2 or it goes
 		// off the right side of the screen.
 		x: (width) / -2
+		// TODO: Ensure the context menu doesn't get its
+		// background pushed away from the button,
+		// which can happen when the user long-presses
+		// on an app at the top of the list.
+		// TODO 2: Prevent the user from scrolling the
+		// All Apps list if they continue to touch
+		// the screen after the context menu opens,
+		// unless that's part of WP. I'll have to check.
 		// We're using the column layout.
 		Column {
 			anchors.fill: parent

--- a/RetiledStyles/AllAppsListEntry.qml
+++ b/RetiledStyles/AllAppsListEntry.qml
@@ -68,6 +68,9 @@ RetiledStyles.Button {
 	// Open the context menu.
 	onPressAndHold: allappscontextmenu.open()
 	
+	// Signal and property for the pin to start button.
+	property string dotDesktopFilePath;
+	signal pinToStart(string dotDesktopFilePath);
 	
 	// Adding the context menus:
 	// https://doc.qt.io/qt-6/qml-qtquick-controls2-popup.html
@@ -90,6 +93,7 @@ RetiledStyles.Button {
 			ButtonBase {
 				width: parent.width
 				text: qsTr("pin to start")
+				onClicked: parent.pinToStart(parent.dotDesktopFilePath)
 			}
 		}
 	}

--- a/RetiledStyles/AllAppsListEntry.qml
+++ b/RetiledStyles/AllAppsListEntry.qml
@@ -73,12 +73,13 @@ RetiledStyles.Button {
 	// https://doc.qt.io/qt-6/qml-qtquick-controls2-popup.html
 	Popup {
 		id: allappscontextmenu
-		anchors.centerIn: parent
+		width: window.width
 		contentWidth: window.width
 		// We're using the column layout.
 		Column {
 			anchors.fill: parent
 			ButtonBase {
+				width: parent.width
 				text: qsTr("pin to start")
 			}
 		}

--- a/RetiledStyles/AllAppsListEntry.qml
+++ b/RetiledStyles/AllAppsListEntry.qml
@@ -31,6 +31,7 @@
 // about missing stuff.
 import "." as RetiledStyles
 import QtQuick
+import QtQuick.Controls
 
 
 // Change the button to be like the All Apps list buttons on WP.
@@ -62,6 +63,9 @@ RetiledStyles.Button {
 	
 	// Have a property for the icon background color.
 	property string iconBackgroundColor: "#0050ef"
+	
+	// Open the context menu.
+	onPressAndHold: allappscontextmenu.open()
 	
 	Row {
 		// Fill the button so we can align things properly.
@@ -98,6 +102,19 @@ RetiledStyles.Button {
 			
 	
 	} // End of the row for the button and text.
+	
+	// Adding the context menus:
+	// https://doc.qt.io/qt-6/qml-qtquick-controls2-popup.html
+	Popup {
+		id: allappscontextmenu
+		// We're using the column layout.
+		Column {
+			anchors.fill: parent
+			ButtonBase {
+				text: qsTr("pin to start")
+			}
+		}
+	}
 	
 } // End of the ButtonBase containing the All Apps list button item.
 

--- a/RetiledStyles/AllAppsListEntry.qml
+++ b/RetiledStyles/AllAppsListEntry.qml
@@ -142,7 +142,6 @@ RetiledStyles.Button {
 	
 	} // End of the row for the button and text.
 	
-	
 } // End of the ButtonBase containing the All Apps list button item.
 
 

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -114,7 +114,7 @@ ButtonBase {
 		
 		// Trying to do a press and hold for the menu.
 		onPressAndHold: {
-			parent.pressAndHold(parent.execKey, parent.newTileWidth, parent.newTileHeight);
+			parent.pressAndHold(parent.dotDesktopFilePath, parent.newTileWidth, parent.newTileHeight);
 		}
 	}
 	
@@ -127,6 +127,7 @@ ButtonBase {
 			anchors.fill: parent
 			ButtonBase {
 				text: qsTr("unpin")
+				onClicked: parent.unpinTile(parent.dotDesktopFilePath)
 			}
 			ButtonBase {
 				text: qsTr("resize (medium)")

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -104,6 +104,26 @@ ButtonBase {
 		onPressed: control.scale = 0.98
 		onReleased: control.scale = 1.0
 		onCanceled: control.scale = 1.0
+		
+		// Trying to do a press and hold for the menu.
+		onPressAndHold: {
+			parent.pressAndHold(parent.tilemenu);
+		}
+	}
+	
+	// Adding the context menus:
+	// https://doc.qt.io/qt-6/qml-qtquick-controls2-popup.html
+	Popup {
+		id: tilemenu
+		// We're using the column layout.
+		ColumnLayout {
+			ButtonBase {
+				text: qsTr("unpin")
+				text: qsTr("resize (medium)")
+				text: qsTr("resize (small)")
+				text: qsTr("resize (wide)")
+			}
+		}
 	}
 	
 	// Override the contentItem using the one from Button.

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -134,7 +134,7 @@ ButtonBase {
 			anchors.fill: parent
 			ButtonBase {
 				text: qsTr("unpin")
-				onClicked: parent.unpinTile(parent.dotDesktopFilePath)
+				onClicked: unpinTile(dotDesktopFilePath)
 			}
 			ButtonBase {
 				text: qsTr("resize (medium)")

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -60,7 +60,11 @@ ButtonBase {
 	property string dotDesktopFilePath;
 	property int newTileWidth;
 	property int newTileHeight;
-	signal pressAndHold(string dotDesktopFilePath, int newTileWidth, int newTileHeight);
+	// Signal for opening the context menu.
+	signal pressAndHold(tilemenu);
+	// Signals for unpinning and resizing tiles.
+	signal unpinTile(string dotDesktopFilePath);
+	signal resizeTile(string dotDesktopFilePath, int newTileWidth, int newTileHeight);
 	
 	// Set padding values.
 	// These values and the fontSize may be incorrect, at least with WP7:
@@ -114,7 +118,7 @@ ButtonBase {
 		
 		// Trying to do a press and hold for the menu.
 		onPressAndHold: {
-			parent.pressAndHold(parent.dotDesktopFilePath, parent.newTileWidth, parent.newTileHeight);
+			parent.pressAndHold();
 		}
 	}
 	

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -119,7 +119,7 @@ ButtonBase {
 		
 		// Trying to do a press and hold for the menu.
 		onPressAndHold: {
-			parent.pressAndHold(parent.showContextMenu);
+			tilemenu.open();
 		}
 	}
 	

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -60,7 +60,7 @@ ButtonBase {
 	property string dotDesktopFilePath;
 	property int newTileWidth;
 	property int newTileHeight;
-	property bool showContextMenu = false
+	property bool showContextMenu: false
 	// Signal for opening the context menu.
 	signal pressAndHold(bool showContextMenu);
 	// Signals for unpinning and resizing tiles.

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -127,6 +127,7 @@ ButtonBase {
 	// https://doc.qt.io/qt-6/qml-qtquick-controls2-popup.html
 	Popup {
 		id: tilemenu
+		modal: true
 		visible: showContextMenu
 		// We're using the column layout.
 		Column {

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -57,9 +57,10 @@ ButtonBase {
 	signal clicked(string execKey);
 	
 	// Add signals for the context menu.
+	property string dotDesktopFilePath;
 	property int newTileWidth;
 	property int newTileHeight;
-	signal pressAndHold(string execKey, int newTileWidth, int newTileHeight);
+	signal pressAndHold(string dotDesktopFilePath, int newTileWidth, int newTileHeight);
 	
 	// Set padding values.
 	// These values and the fontSize may be incorrect, at least with WP7:

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -60,8 +60,9 @@ ButtonBase {
 	property string dotDesktopFilePath;
 	property int newTileWidth;
 	property int newTileHeight;
+	property bool showContextMenu = false
 	// Signal for opening the context menu.
-	signal pressAndHold(tilemenu);
+	signal pressAndHold(bool showContextMenu);
 	// Signals for unpinning and resizing tiles.
 	signal unpinTile(string dotDesktopFilePath);
 	signal resizeTile(string dotDesktopFilePath, int newTileWidth, int newTileHeight);
@@ -126,6 +127,7 @@ ButtonBase {
 	// https://doc.qt.io/qt-6/qml-qtquick-controls2-popup.html
 	Popup {
 		id: tilemenu
+		visible: showContextMenu
 		// We're using the column layout.
 		Column {
 			anchors.fill: parent

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -138,15 +138,15 @@ ButtonBase {
 			}
 			ButtonBase {
 				text: qsTr("resize (medium)")
-				onClicked: parent.resizeTile(parent.dotDesktopFilePath, 150, 150)
+				onClicked: resizeTile(dotDesktopFilePath, 150, 150)
 			}
 			ButtonBase {
 				text: qsTr("resize (small)")
-				onClicked: parent.resizeTile(parent.dotDesktopFilePath, 70, 70)
+				onClicked: resizeTile(dotDesktopFilePath, 70, 70)
 			}
 			ButtonBase {
 				text: qsTr("resize (wide)")
-				onClicked: parent.resizeTile(parent.dotDesktopFilePath, 310, 150)
+				onClicked: resizeTile(dotDesktopFilePath, 310, 150)
 			}
 		}
 	}

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -56,6 +56,11 @@ ButtonBase {
 	property string execKey;
 	signal clicked(string execKey);
 	
+	// Add signals for the context menu.
+	property int newTileWidth;
+	property int newTileHeight;
+	signal pressAndHold(string execKey, int newTileWidth, int newTileHeight);
+	
 	// Set padding values.
 	// These values and the fontSize may be incorrect, at least with WP7:
 	// https://stackoverflow.com/a/8430030

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -113,7 +113,7 @@ ButtonBase {
 		
 		// Trying to do a press and hold for the menu.
 		onPressAndHold: {
-			parent.pressAndHold(parent.tilemenu);
+			parent.pressAndHold(parent.execKey, parent.newTileWidth, parent.newTileHeight);
 		}
 	}
 	

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -33,6 +33,7 @@
 // until I can figure out a better solution.
 import "."
 import QtQuick
+import QtQuick.Controls
 
 ButtonBase {
 	// We need to change things to make it into a tile.
@@ -116,7 +117,7 @@ ButtonBase {
 	Popup {
 		id: tilemenu
 		// We're using the column layout.
-		ColumnLayout {
+		Column {
 			anchors.fill: parent
 			ButtonBase {
 				text: qsTr("unpin")

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -117,10 +117,17 @@ ButtonBase {
 		id: tilemenu
 		// We're using the column layout.
 		ColumnLayout {
+			anchors.fill: parent
 			ButtonBase {
 				text: qsTr("unpin")
+			}
+			ButtonBase {
 				text: qsTr("resize (medium)")
+			}
+			ButtonBase {
 				text: qsTr("resize (small)")
+			}
+			ButtonBase {
 				text: qsTr("resize (wide)")
 			}
 		}

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -119,7 +119,7 @@ ButtonBase {
 		
 		// Trying to do a press and hold for the menu.
 		onPressAndHold: {
-			parent.pressAndHold(true);
+			parent.pressAndHold(parent.showContextMenu);
 		}
 	}
 	

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -131,12 +131,15 @@ ButtonBase {
 			}
 			ButtonBase {
 				text: qsTr("resize (medium)")
+				onClicked: parent.resizeTile(parent.dotDesktopFilePath, 150, 150)
 			}
 			ButtonBase {
 				text: qsTr("resize (small)")
+				onClicked: parent.resizeTile(parent.dotDesktopFilePath, 70, 70)
 			}
 			ButtonBase {
 				text: qsTr("resize (wide)")
+				onClicked: parent.resizeTile(parent.dotDesktopFilePath, 310, 150)
 			}
 		}
 	}

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -119,7 +119,7 @@ ButtonBase {
 		
 		// Trying to do a press and hold for the menu.
 		onPressAndHold: {
-			parent.pressAndHold();
+			parent.pressAndHold(true);
 		}
 	}
 	

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -58,8 +58,6 @@ ButtonBase {
 	
 	// Add signals for the context menu.
 	property string dotDesktopFilePath;
-	property int newTileWidth;
-	property int newTileHeight;
 	property bool showContextMenu: false
 	// Signal for opening the context menu.
 	signal pressAndHold(bool showContextMenu);


### PR DESCRIPTION
Tiles and All Apps list items now have context menus! Currently their code just prints what it's sent, but the good news is I have access to everything important in Python! There's probably some stuff that needs to be removed or cleaned up to improve memory usage, and I need to make the context menus actually look like Windows Phone context menus, but it's getting there. Eventually tiles will have their proper circular buttons, but I don't know how to do that yet, and I'd rather not delay things until I do. I also need to figure out how to remove and resize the tiles at runtime.

Fun fact: This is about where I was 2.25 months ago, and with the benefit of hindsight so I didn't have to do as much research and experimentation to make sure things were correct to Windows Phone 8.x, I got to the same place I reached after 6 months the first time.