### PR TITLE
Go to and stay in the All Apps list if every tile is unpinned, even when relaunching.

### DIFF
--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/tileslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/tileslist.py
@@ -51,6 +51,8 @@ def saveTilesList(tilesList):
 	# Define a list we'll use to store the dictionary in.
 	TilesListToSave = []
 	
+	print(tilesList)
+	
 	# Loop through the list of dictionaries and append to
 	# the list using what's in each dictionary.
 	# Context for how we're getting the items appended:

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/tileslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/tileslist.py
@@ -51,8 +51,6 @@ def saveTilesList(tilesList):
 	# Define a list we'll use to store the dictionary in.
 	TilesListToSave = []
 	
-	print(tilesList)
-	
 	# Loop through the list of dictionaries and append to
 	# the list using what's in each dictionary.
 	# Context for how we're getting the items appended:

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -351,15 +351,18 @@ ApplicationWindow {
 						// Set the interactivity of the SwipeView back to True
 						// if it's currently false:
 						// https://doc.qt.io/qt-6/qml-qtquick-controls2-swipeview.html#interactive-prop
-						if (startScreenView.interactive == false) {
+						// First make sure we're not in global edit mode.
+						if (globalEditMode == false) {
+							if (startScreenView.interactive == false) {
 							// Allow it to be interactive again and switch to it.
-							startScreenView.interactive = true;
-							startScreenView.currentIndex = 0;
+								startScreenView.interactive = true;
+								startScreenView.currentIndex = 0;
 							// Show the All Apps button again, too.
-							allAppsButton.visible = true;
+								allAppsButton.visible = true;
 							// Reset the Back button/Escape key shortcut.
-							backButtonShortcut.enabled = true;
-						} // End of if statement seeing if the swipeview is currently interactive.
+								backButtonShortcut.enabled = true;
+							} // End of if statement seeing if the swipeview is currently interactive.
+						}
 					} else {
 						// There are either 0 or fewer tiles pinned, so hide the tiles page.
 						// It's unlikely that there will be fewer than 0 tiles, but

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -521,5 +521,5 @@ ApplicationWindow {
 		// The All Apps page has been moved to its own file.
 	}
 	
-}
-}
+} // End of the swipeview for the Start screen.
+}// End of the window.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -255,6 +255,13 @@ ApplicationWindow {
 					// turned on.
 					globalEditMode = enable;
 					
+					// Set the visibility of the All Apps list button
+					// and the ability to use the swipeview to the
+					// "enable" boolean, too.
+					// We have to use the opposite of enable, actually.
+					allAppsButton.visible = !enable;
+					startScreenView.interactive = !enable;
+					
 					// Now if global edit mode gets turned off, we
 					// need to save the tile layout.
 					if (globalEditMode == false) {

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -380,14 +380,19 @@ ApplicationWindow {
 					// figure out why it wouldn't work.
 					var ParsedTilesList = JSON.parse(TilesList);
 					
+					// Make sure the tiles list isn't just an empty list
+					// before we create the tiles list. This allows the user
+					// to just not have tiles if they don't want to.
+					if (ParsedTilesList.length > 0) {
+					
 					// Create the tiles dynamically according to this page:
 					// https://doc.qt.io/qt-6/qtqml-javascript-dynamicobjectcreation.html
 					// We're doing this outside the loop, because that's what the docs
 					// did and it's probably faster/less memory-intensive.
 					// TODO: Check if this can be changed to RetiledStyles.Tile.
-					var TileComponent = Qt.createComponent("../../../RetiledStyles/Tile.qml");
+						var TileComponent = Qt.createComponent("../../../RetiledStyles/Tile.qml");
 					
-					for (var i = 0; i < ParsedTilesList.length; i++){
+						for (var i = 0; i < ParsedTilesList.length; i++){
 						//console.log(ParsedTilesList[i].DotDesktopPath);
 						//console.log(ParsedTilesList[i].TileAppNameAreaText);
 						//console.log(ParsedTilesList[i].TileWidth);
@@ -399,49 +404,57 @@ ApplicationWindow {
 						// Make sure it's ready first.
 						// TODO: Switch to incubateObject.
 						//if (TileComponent.status == Component.Ready) {
-						var NewTileObject = TileComponent.createObject(tilesContainer);
+							var NewTileObject = TileComponent.createObject(tilesContainer);
 						// Increment the tile count.
-						checkPinnedTileCount(1);
+							checkPinnedTileCount(1);
 						// Set tile properties.
-						NewTileObject.tileText = ParsedTilesList[i].TileAppNameAreaText;
-						NewTileObject.width = ParsedTilesList[i].TileWidth;
-						NewTileObject.height = ParsedTilesList[i].TileHeight;
-						NewTileObject.tileBackgroundColor = ParsedTilesList[i].TileColor;
+							NewTileObject.tileText = ParsedTilesList[i].TileAppNameAreaText;
+							NewTileObject.width = ParsedTilesList[i].TileWidth;
+							NewTileObject.height = ParsedTilesList[i].TileHeight;
+							NewTileObject.tileBackgroundColor = ParsedTilesList[i].TileColor;
 						// Doesn't quite work on Windows because the hardcoded tile is trying to read
 						// from /usr/share/applications and can't find Firefox.
 						// Turns out it was trying to run Firefox. Not sure how to stop that.
 						// Actually, I think this involves an event handler:
 						// https://stackoverflow.com/a/22605752
-						NewTileObject.execKey = ParsedTilesList[i].DotDesktopFilePath;
+							NewTileObject.execKey = ParsedTilesList[i].DotDesktopFilePath;
 						
 						// Set the .desktop file path for unpinning or resizing.
-						NewTileObject.dotDesktopFilePath = ParsedTilesList[i].DotDesktopFilePath;
+							NewTileObject.dotDesktopFilePath = ParsedTilesList[i].DotDesktopFilePath;
 						
 						// Set tile index for the edit mode.
-						NewTileObject.tileIndex = i
+							NewTileObject.tileIndex = i
 						
 						// Connect clicked signal.
-						NewTileObject.clicked.connect(tileClicked);
+							NewTileObject.clicked.connect(tileClicked);
 						
 						// Connect global edit mode toggle.
-						NewTileObject.toggleGlobalEditMode.connect(toggleGlobalEditMode);
+							NewTileObject.toggleGlobalEditMode.connect(toggleGlobalEditMode);
 						
 						// Connect hideEditModeControlsOnPreviousTile signal.
-						NewTileObject.hideEditModeControlsOnPreviousTile.connect(hideEditModeControlsOnPreviousTile);
+							NewTileObject.hideEditModeControlsOnPreviousTile.connect(hideEditModeControlsOnPreviousTile);
 						
 						// Connect the opacity-setter function.
-						NewTileObject.setTileOpacity.connect(setTileOpacity);
+							NewTileObject.setTileOpacity.connect(setTileOpacity);
 						
 						// Connect long-press signal.
 						// NewTileObject.pressAndHold.connect(tileLongPressed);
 						
 						// Connect decrementing the pinned tiles count signal.
-						NewTileObject.decrementPinnedTilesCount.connect(checkPinnedTileCount);
+							NewTileObject.decrementPinnedTilesCount.connect(checkPinnedTileCount);
 						
 						//} // End of If statement to ensure things are ready.
 						
-					} // End of For loop that loads the tiles.
-					
+						} // End of For loop that loads the tiles.
+					} else {
+						// We have to add 0 to 0 if there are no tiles to add
+						// so that the whole thing where the tiles list is hidden
+						// happens.
+						// There's an animation that occurs where the page slides over
+						// to the All Apps list, and I'd prefer to turn that off on
+						// startup if possible, but allow it to be used later.
+						checkPinnedTileCount(0);
+					} // End of If statement checking to ensure there are tiles to add.
 					
 				} // Component.onCompleted for the Tiles Flow area.
 				

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -328,6 +328,11 @@ ApplicationWindow {
 					// This can be positive or negative, as we're using addition.
 					pinnedTilesCount = pinnedTilesCount + numberToChangePinnedTilesCountBy;
 					
+					// TODO: Include this when pinning tiles. Actually, I think what
+					// can be done is that we can get the All Apps button's y-value
+					// and scroll to it to show the newly-added tile. Hopefully that
+					// works.
+					
 					// Check whether the pinnedTilesCount is above 0, and show the pinned
 					// tiles list if it's currently not showing.
 					if (pinnedTilesCount > 0) {

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -354,8 +354,10 @@ ApplicationWindow {
 							// } else if ((startScreenView.interactive == true) && (startScreenView.currentIndex == 1)) {
 								// // Move to the bottom of the tiles list, as we're pinning a tile:
 								// // https://stackoverflow.com/a/25363306
-								// // The other answer on that page may also help.
-								// tilesFlickable.contentY = tilesFlickable.contentHeight-allAppsButton.height;
+								// // As it turns out, you have to use the flickable's values
+								// // for both contentHeight and height in order for this to work,
+								// // or it won't be the right position.
+								// tilesFlickable.contentY = tilesFlickable.contentHeight-tilesFlickable.height;
 								// startScreenView.currentIndex = 0;
 								// Not sure if this code will help when I'm trying to figure out
 								// moving to the bottom to pin tiles.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -348,6 +348,8 @@ ApplicationWindow {
 							startScreenView.interactive = false;
 							startScreenView.currentIndex = 1;
 							allAppsButton.visible = false;
+							// Exit global edit mode.
+							toggleGlobalEditMode(false);
 						} // End of if statement seeing if the swipeview is currently interactive.
 					} // End of if statement checking if the number of pinned tiles is above 0.
 				} // End of function checking the pinned tile count.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -433,7 +433,7 @@ ApplicationWindow {
 					
 				} // Component.onCompleted for the Tiles Flow area.
 				
-			}
+			} // End of the Flow that contains the tiles.
 	
 		// Use a FontLoader to get the arrow button font:
 		// https://doc.qt.io/qt-6/qml-qtquick-fontloader.html

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -112,6 +112,7 @@ ApplicationWindow {
 	
 	
 	Shortcut {
+		id: backButtonShortcut
 		sequences: ["Esc", "Back"]
         onActivated: {
 			
@@ -339,6 +340,8 @@ ApplicationWindow {
 							startScreenView.currentIndex = 0;
 							// Show the All Apps button again, too.
 							allAppsButton.visible = true;
+							// Reset the Back button/Escape key shortcut.
+							backButtonShortcut.enabled = true;
 						} // End of if statement seeing if the swipeview is currently interactive.
 					} else {
 						// There are either 0 or fewer tiles pinned, so hide the tiles page.
@@ -361,6 +364,8 @@ ApplicationWindow {
 							// until I read it again.
 							// startScreenView.contentItem.highlightMoveDuration = defaultSwipeViewMoveAnimationDuration
 							allAppsButton.visible = false;
+							// Turn off the back button shortcut.
+							backButtonShortcut.enabled = false;
 							// Loop through the tiles list and make sure they're
 							// all hidden, because I was having an issue where
 							// one would remain for some reason.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -316,6 +316,7 @@ ApplicationWindow {
 							tilesContainer.children[i].scale = 0.9;
 						}
 					}
+				}
 				
 				// Hide or show tiles page based on the current number of tiles.
 				function checkPinnedTileCount(numberToChangePinnedTilesCountBy) {

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -321,7 +321,7 @@ ApplicationWindow {
 				function checkPinnedTileCount(numberToChangePinnedTilesCountBy) {
 					// Add the number to change the pinned tiles count by.
 					// This can be positive or negative, as we're using addition.
-					pinnedTilesCount = pinnedTilesCount + numberToChangePinnedTilesCountBy
+					pinnedTilesCount = pinnedTilesCount + numberToChangePinnedTilesCountBy;
 					
 					// Check whether the pinnedTilesCount is above 0, and show the pinned
 					// tiles list if it's currently not showing.
@@ -359,7 +359,7 @@ ApplicationWindow {
 					// We're using the last example here, with the books:
 					// https://www.microverse.org/blog/how-to-loop-through-the-array-of-json-objects-in-javascript
 					// Most of that example was used in the for loop below, but I changed some stuff.
-					var TilesList = tilesListViewModel.getTilesList()
+					var TilesList = tilesListViewModel.getTilesList();
 					//console.log(TilesList)
 					
 					// Remember to parse the JSON.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -245,16 +245,6 @@ ApplicationWindow {
 					tilesListViewModel.RunApp(execKey);
 				}
 				
-				// Set up the signals for the tile context menu.
-				// Unpin tiles.
-				function unpinTile(dotDesktopFilePath) {
-					tilesListViewModel.UnpinTile(dotDesktopFilePath);
-				}
-				// Resize tiles.
-				function resizeTile(dotDesktopFilePath, newTileWidth, newTileHeight) {
-					tilesListViewModel.ResizeTile(dotDesktopFilePath, newTileWidth, newTileHeight);
-				}
-				
 				// Turn on or off global edit mode.
 				function toggleGlobalEditMode(enable, showAllAppsButtonAndAllowGoingBetweenPages) {
 					// If enable is false, global edit mode will be

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -348,6 +348,16 @@ ApplicationWindow {
 							startScreenView.interactive = false;
 							startScreenView.currentIndex = 1;
 							allAppsButton.visible = false;
+							// Loop through the tiles list and make sure they're
+							// all hidden, because I was having an issue where
+							// one would remain for some reason.
+							for (var i = 0; i < tilesContainer.children.length; i++) {
+								if (tilesContainer.children[i].visible == true) {
+								// Get the properties from the tiles
+								// and add them to the list.
+								tilesContainer.children[i].visible = false;
+								} // End of If statement checking if the tile is visible.
+							} // End of for loop checking if any tiles are visible when they shouldn't be.
 							// Exit global edit mode.
 							toggleGlobalEditMode(false);
 						} // End of if statement seeing if the swipeview is currently interactive.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -351,6 +351,14 @@ ApplicationWindow {
 								allAppsButton.visible = true;
 							// Reset the Back button/Escape key shortcut.
 								backButtonShortcut.enabled = true;
+							// } else if ((startScreenView.interactive == true) && (startScreenView.currentIndex == 1)) {
+								// // Move to the bottom of the tiles list, as we're pinning a tile:
+								// // https://stackoverflow.com/a/25363306
+								// // The other answer on that page may also help.
+								// tilesFlickable.contentY = tilesFlickable.contentHeight-allAppsButton.height;
+								// startScreenView.currentIndex = 0;
+								// Not sure if this code will help when I'm trying to figure out
+								// moving to the bottom to pin tiles.
 							} // End of if statement seeing if the swipeview is currently interactive.
 						} // End of global edit mode check.
 					} else {

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -83,6 +83,9 @@ ApplicationWindow {
 	// to see whether the tiles page should be shown or hidden.
 	property int pinnedTilesCount: 0
 	
+	// Save the default animation time for the swipeview.
+	property int defaultSwipeViewMoveAnimationDuration: startScreenView.contentItem.highlightMoveDuration
+	
 	// Load Open Sans ~~SemiBold~~ Regular (see below) for the tile text:
 	// https://stackoverflow.com/a/8430030
 	// It's possible that Windows Phone switched to
@@ -319,7 +322,7 @@ ApplicationWindow {
 				} // End of the tile-opacity function.
 				
 				// Hide or show tiles page based on the current number of tiles.
-				function checkPinnedTileCount(numberToChangePinnedTilesCountBy) {
+				function checkPinnedTileCount(numberToChangePinnedTilesCountBy, showAnimation) {
 					// Add the number to change the pinned tiles count by.
 					// This can be positive or negative, as we're using addition.
 					pinnedTilesCount = pinnedTilesCount + numberToChangePinnedTilesCountBy;
@@ -346,7 +349,17 @@ ApplicationWindow {
 							// lock the user to the All Apps list, and
 							// hide the All Apps button.
 							startScreenView.interactive = false;
+							// Turn off the animation so the All Apps list is right there:
+							// https://forum.qt.io/topic/81535/swipeview-page-change-without-animation
+							// Set the animation to 0.
+							if (showAnimation == false) {
+								startScreenView.contentItem.highlightMoveDuration = 0
+							}
 							startScreenView.currentIndex = 1;
+							// Set the animation duration back to the default.
+							// Didn't know this is what the original post actually did
+							// until I read it again.
+							// startScreenView.contentItem.highlightMoveDuration = defaultSwipeViewMoveAnimationDuration
 							allAppsButton.visible = false;
 							// Loop through the tiles list and make sure they're
 							// all hidden, because I was having an issue where
@@ -360,6 +373,9 @@ ApplicationWindow {
 							} // End of for loop checking if any tiles are visible when they shouldn't be.
 							// Exit global edit mode.
 							toggleGlobalEditMode(false);
+							// Set the animation duration back to the default, since we're
+							// probably already in the all apps list.
+							startScreenView.contentItem.highlightMoveDuration = defaultSwipeViewMoveAnimationDuration
 						} // End of if statement seeing if the swipeview is currently interactive.
 					} // End of if statement checking if the number of pinned tiles is above 0.
 				} // End of function checking the pinned tile count.
@@ -406,7 +422,7 @@ ApplicationWindow {
 						//if (TileComponent.status == Component.Ready) {
 							var NewTileObject = TileComponent.createObject(tilesContainer);
 						// Increment the tile count.
-							checkPinnedTileCount(1);
+							checkPinnedTileCount(1, true);
 						// Set tile properties.
 							NewTileObject.tileText = ParsedTilesList[i].TileAppNameAreaText;
 							NewTileObject.width = ParsedTilesList[i].TileWidth;
@@ -453,7 +469,7 @@ ApplicationWindow {
 						// There's an animation that occurs where the page slides over
 						// to the All Apps list, and I'd prefer to turn that off on
 						// startup if possible, but allow it to be used later.
-						checkPinnedTileCount(0);
+						checkPinnedTileCount(0, false);
 					} // End of If statement checking to ensure there are tiles to add.
 					
 				} // Component.onCompleted for the Tiles Flow area.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -295,7 +295,7 @@ ApplicationWindow {
 							tilesContainer.children[i].z = tilesContainer.children[i].z - 1;
 						}
 					}
-				}
+				} // End of the function that hides edit mode controls on the previous tile.
 				
 				// Set opacity to 0.5 for tiles not in edit mode.
 				function setTileOpacity() {
@@ -316,7 +316,7 @@ ApplicationWindow {
 							tilesContainer.children[i].scale = 0.9;
 						}
 					}
-				}
+				} // End of the tile-opacity function.
 				
 				// Hide or show tiles page based on the current number of tiles.
 				function checkPinnedTileCount(numberToChangePinnedTilesCountBy) {

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -322,7 +322,34 @@ ApplicationWindow {
 					// Add the number to change the pinned tiles count by.
 					// This can be positive or negative, as we're using addition.
 					pinnedTilesCount = pinnedTilesCount + numberToChangePinnedTilesCountBy
-				}
+					
+					// Check whether the pinnedTilesCount is above 0, and show the pinned
+					// tiles list if it's currently not showing.
+					if (pinnedTilesCount > 0) {
+						// Set the interactivity of the SwipeView back to True
+						// if it's currently false:
+						// https://doc.qt.io/qt-6/qml-qtquick-controls2-swipeview.html#interactive-prop
+						if (startScreenView.interactive == false) {
+							// Allow it to be interactive again and switch to it.
+							startScreenView.interactive = true;
+							startScreenView.currentIndex = 0;
+							// Show the All Apps button again, too.
+							allAppsButton.visible = true;
+						} // End of if statement seeing if the swipeview is currently interactive.
+					} else {
+						// There are either 0 or fewer tiles pinned, so hide the tiles page.
+						// It's unlikely that there will be fewer than 0 tiles, but
+						// I'm just allowing for the possibility to ensure things don't break.
+						if (startScreenView.interactive == false) {
+							// Prevent interaction with the swipeview,
+							// lock the user to the All Apps list, and
+							// hide the All Apps button.
+							startScreenView.interactive = false;
+							startScreenView.currentIndex = 1;
+							allAppsButton.visible = false;
+						} // End of if statement seeing if the swipeview is currently interactive.
+					} // End of if statement checking if the number of pinned tiles is above 0.
+				} // End of function checking the pinned tile count.
 				
 				Component.onCompleted: {
 					

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -514,8 +514,8 @@ ApplicationWindow {
 		
 		} // End of RowLayout for storing empty items that form the margins on the left and right.
 		
-	}
-	}
+	} // End of the flickable for the tiles area, which includes the margins.
+	} // End of the item containing the tiles area.
 	
 	RetiledStartPages.AllApps {
 		// The All Apps page has been moved to its own file.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -422,11 +422,8 @@ ApplicationWindow {
 						// Connect long-press signal.
 						// NewTileObject.pressAndHold.connect(tileLongPressed);
 						
-						// Connect unpin signal.
-						NewTileObject.unpinTile.connect(unpinTile);
-						
-						// Connect resize signal.
-						NewTileObject.resizeTile.connect(resizeTile);
+						// Connect decrementing the pinned tiles count signal.
+						NewTileObject.decrementPinnedTilesCount.connect(checkPinnedTileCount);
 						
 						//} // End of If statement to ensure things are ready.
 						

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -316,6 +316,12 @@ ApplicationWindow {
 							tilesContainer.children[i].scale = 0.9;
 						}
 					}
+				
+				// Hide or show tiles page based on the current number of tiles.
+				function checkPinnedTileCount(numberToChangePinnedTilesCountBy) {
+					// Add the number to change the pinned tiles count by.
+					// This can be positive or negative, as we're using addition.
+					pinnedTilesCount = pinnedTilesCount + numberToChangePinnedTilesCountBy
 				}
 				
 				Component.onCompleted: {
@@ -354,6 +360,8 @@ ApplicationWindow {
 						// TODO: Switch to incubateObject.
 						//if (TileComponent.status == Component.Ready) {
 						var NewTileObject = TileComponent.createObject(tilesContainer);
+						// Increment the tile count.
+						checkPinnedTileCount(1);
 						// Set tile properties.
 						NewTileObject.tileText = ParsedTilesList[i].TileAppNameAreaText;
 						NewTileObject.width = ParsedTilesList[i].TileWidth;

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -76,6 +76,13 @@ ApplicationWindow {
 	// global edit mode is off.
 	property int previousTileInEditingModeIndex;
 	
+	// We're using this to keep track of how many tiles
+	// are on Start. Adding a tile increases this number
+	// by 1, and unpinning a tile decreases it by 1.
+	// This is checked every time a tile is pinned or unpinned
+	// to see whether the tiles page should be shown or hidden.
+	property int pinnedTilesCount: 0
+	
 	// Load Open Sans ~~SemiBold~~ Regular (see below) for the tile text:
 	// https://stackoverflow.com/a/8430030
 	// It's possible that Windows Phone switched to

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -127,6 +127,13 @@ ApplicationWindow {
 			// not conflict with the keyboard shortcut
 			// in the main window's file that goes back.
 			
+			// TODO 2: Figure out how to let this be sent
+			// at any time so that the user can, for example,
+			// swipe over to the All Apps list and immediately
+			// press the Back button so it goes back right away.
+			// I did that sometimes because it was fun, and I want
+			// other people to have that experience available to them.
+			
         }
     }
 	
@@ -249,18 +256,16 @@ ApplicationWindow {
 				}
 				
 				// Turn on or off global edit mode.
-				function toggleGlobalEditMode(enable) {
+				function toggleGlobalEditMode(enable, showAllAppsButtonAndAllowGoingBetweenPages) {
 					// If enable is false, global edit mode will be
 					// turned off. Likewise, if it's true, it'll be
 					// turned on.
 					globalEditMode = enable;
 					
-					// Set the visibility of the All Apps list button
-					// and the ability to use the swipeview to the
-					// "enable" boolean, too.
-					// We have to use the opposite of enable, actually.
-					allAppsButton.visible = !enable;
-					startScreenView.interactive = !enable;
+					// Hide the All Apps button and don't let the user
+					// open the All Apps list based on showAllAppsButtonAndAllowGoingBetweenPages.
+					allAppsButton.visible = showAllAppsButtonAndAllowGoingBetweenPages;
+					startScreenView.interactive = showAllAppsButtonAndAllowGoingBetweenPages;
 					
 					// Now if global edit mode gets turned off, we
 					// need to save the tile layout.
@@ -388,7 +393,9 @@ ApplicationWindow {
 								} // End of If statement checking if the tile is visible.
 							} // End of for loop checking if any tiles are visible when they shouldn't be.
 							// Exit global edit mode.
-							toggleGlobalEditMode(false);
+							// Also don't show the all apps button or let the user go
+							// back to the tiles list.
+							toggleGlobalEditMode(false, false);
 							// Set the animation duration back to the default, since we're
 							// probably already in the all apps list.
 							// Didn't know this is what the original post actually did

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -354,15 +354,14 @@ ApplicationWindow {
 							startScreenView.interactive = false;
 							// Turn off the animation so the All Apps list is right there:
 							// https://forum.qt.io/topic/81535/swipeview-page-change-without-animation
-							// Set the animation to 0.
+							// Set the animation to 0 if the calling code wants it.
+							// This is the case if no tiles are pinned on startup,
+							// but if they're unpinned at runtime, we need to have
+							// an animation.
 							if (showAnimation == false) {
 								startScreenView.contentItem.highlightMoveDuration = 0
 							}
 							startScreenView.currentIndex = 1;
-							// Set the animation duration back to the default.
-							// Didn't know this is what the original post actually did
-							// until I read it again.
-							// startScreenView.contentItem.highlightMoveDuration = defaultSwipeViewMoveAnimationDuration
 							allAppsButton.visible = false;
 							// Turn off the back button shortcut.
 							backButtonShortcut.enabled = false;
@@ -380,6 +379,9 @@ ApplicationWindow {
 							toggleGlobalEditMode(false);
 							// Set the animation duration back to the default, since we're
 							// probably already in the all apps list.
+							// Didn't know this is what the original post actually did
+							// until I read it again.
+							// NOTE: You have to wait a little while, or it won't be instant.
 							startScreenView.contentItem.highlightMoveDuration = defaultSwipeViewMoveAnimationDuration
 						} // End of if statement seeing if the swipeview is currently interactive.
 					} // End of if statement checking if the number of pinned tiles is above 0.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -362,12 +362,13 @@ ApplicationWindow {
 							// Reset the Back button/Escape key shortcut.
 								backButtonShortcut.enabled = true;
 							} // End of if statement seeing if the swipeview is currently interactive.
-						}
+						} // End of global edit mode check.
 					} else {
 						// There are either 0 or fewer tiles pinned, so hide the tiles page.
 						// It's unlikely that there will be fewer than 0 tiles, but
 						// I'm just allowing for the possibility to ensure things don't break.
-						if (startScreenView.interactive == true) {
+						// Also check to see if global edit mode is currently on.
+						if ((startScreenView.interactive == true) || (globalEditMode == true)) {
 							// Prevent interaction with the swipeview,
 							// lock the user to the All Apps list, and
 							// hide the All Apps button.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -340,7 +340,7 @@ ApplicationWindow {
 						// There are either 0 or fewer tiles pinned, so hide the tiles page.
 						// It's unlikely that there will be fewer than 0 tiles, but
 						// I'm just allowing for the possibility to ensure things don't break.
-						if (startScreenView.interactive == false) {
+						if (startScreenView.interactive == true) {
 							// Prevent interaction with the swipeview,
 							// lock the user to the All Apps list, and
 							// hide the All Apps button.

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -69,7 +69,7 @@ ButtonBase {
 	signal decrementPinnedTilesCount(int amountToDecrement);
 	
 	// Signal for turning on or off global edit mode.
-	signal toggleGlobalEditMode(bool enable);
+	signal toggleGlobalEditMode(bool enable, bool showAllAppsButtonAndAllowGoingBetweenPages);
 	
 	// Signal for hiding the editing controls on the previously-active tile.
 	signal hideEditModeControlsOnPreviousTile(int previousTileInEditingModeIndex);
@@ -274,7 +274,7 @@ ButtonBase {
 				// Also turn off global edit mode, because
 				// the current tile has focus and that's how
 				// global edit mode is turned off.
-				toggleGlobalEditMode(false);
+				toggleGlobalEditMode(false, true);
 				// Set tile opacity, too.
 				setTileOpacity();
 				// Hide the edit mode buttons and reset the tile's
@@ -339,6 +339,8 @@ ButtonBase {
 				control.scale = 0.98
 			}
 		}
+		
+		
 		onReleased: control.scale = 1.0
 		onCanceled: control.scale = 1.0
 		
@@ -368,7 +370,7 @@ ButtonBase {
 			// Turn on edit mode.
 			editMode = true;
 			// Turn on global edit mode.
-			toggleGlobalEditMode(true);
+			toggleGlobalEditMode(true, false);
 			// Set tile opacity, too.
 			setTileOpacity();
 			// Now set the previous tile index.

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -340,9 +340,18 @@ ButtonBase {
 			}
 		}
 		
-		
-		onReleased: control.scale = 1.0
-		onCanceled: control.scale = 1.0
+		onReleased: {
+			// Make sure global edit mode isn't on first.
+			if (globalEditMode == false) {
+				control.scale = 1.0
+			}
+		}
+		onCanceled: {
+			// Make sure global edit mode isn't on first.
+			if (globalEditMode == false) {
+				control.scale = 1.0
+			}
+		}
 		
 		// Trying to do a press and hold for edit mode.
 		onPressAndHold: {

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -64,9 +64,9 @@ ButtonBase {
 	property bool showContextMenu: false
 	// Signal for opening the context menu.
 	signal pressAndHold(bool showContextMenu);
-	// Signals for unpinning and resizing tiles.
-	signal unpinTile(string dotDesktopFilePath);
-	signal resizeTile(string dotDesktopFilePath, int newTileWidth, int newTileHeight);
+	// Signal for decrementing the pinned tiles count.
+	// This is used to check whether the tiles page should be hidden.
+	signal decrementPinnedTilesCount(int amountToDecrement);
 	
 	// Signal for turning on or off global edit mode.
 	signal toggleGlobalEditMode(bool enable);
@@ -151,7 +151,9 @@ ButtonBase {
 			control.z = control.z - 1;
 			// Turn off local edit mode.
 			editMode = false;
+			// Decrement the pinned tiles count.
 			// Unpin the tile.
+			decrementPinnedTilesCount(-1);
 			// Temporary placeholder code that just
 			// sets the tile to be invisible.
 			// TODO: Figure out how to properly remove the tile

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -63,7 +63,7 @@ ButtonBase {
 	property string dotDesktopFilePath;
 	property bool showContextMenu: false
 	// Signal for opening the context menu.
-	signal pressAndHold(bool showContextMenu);
+	// signal pressAndHold(bool showContextMenu);
 	// Signal for decrementing the pinned tiles count.
 	// This is used to check whether the tiles page should be hidden.
 	signal decrementPinnedTilesCount(int amountToDecrement);


### PR DESCRIPTION
Not much point in loading to a blank tiles area when they're all unpinned. I'm sure at least someone used Windows Phone without tiles, so this should be perfect for them. We're also hiding the All Apps button and preventing the All Apps list from being opened when in global edit mode. Additionally, tiles no longer change their size if they're clicked and dragged such that a press and release or cancel occurs when they're not being edited (local edit mode) but the tiles list is in global edit mode (any tile can be placed into local edit mode if they're not already there when in global edit mode if they're clicked or tapped).

The way we're seeing if we should move to the All Apps list is by incrementing or decrementing an integer when loading the tiles list and unpinning them (unpinning will be available soon I hope), then checking if that integer is 0 (zero). If it is 0, then we go over to the All Apps list and hide the All Apps button. Pinning an app will allow the user to go back to the tiles list, but that's not ready yet. I did figure out how to scroll to the bottom of the tiles list at least, which will help when I pin tiles.