### PR TITLE
Pin tiles.

### DIFF
--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/appslist.py
@@ -63,7 +63,13 @@ def RunApp(DotDesktopFilePath):
 
 def GetAppName(DotDesktopFilePath):
 	# Gets the app's name using the libdotdesktop_py library.
-	return desktopEntryStuff.getInfo(DotDesktopFilePath, "Name", DotDesktopFilePath, "", True)
+	# This is different on Windows for debugging purposes.
+	# Example code for sys.platform:
+	# https://docs.python.org/3/library/sys.html#sys.platform
+	if sys.platform.startswith("win32"):
+		return desktopEntryStuff.getInfo("C:\\Users\\drewn\\Desktop\\" + DotDesktopFilePath, "Name", DotDesktopFilePath, "", True)
+	else:
+		return desktopEntryStuff.getInfo("/usr/share/applications/" + DotDesktopFilePath, "Name", DotDesktopFilePath, "", True)
 	
 def getDotDesktopFiles():
 	# Gets the list of .desktop files and creates a list of objects

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/startlayout.yaml
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/startlayout.yaml
@@ -35,39 +35,39 @@
 
 # This file was partially based on the winget installer manifest spec.
 Tiles:
-- DotDesktopFilePath: "/usr/share/applications/firefox.desktop"
+- DotDesktopFilePath: "firefox.desktop"
   TileColor: "#0050ef"
   TileWidth: 150
   TileHeight: 150
-- DotDesktopFilePath: "/usr/share/applications/org.kde.angelfish.desktop"
+- DotDesktopFilePath: "org.kde.angelfish.desktop"
   TileColor: "#0050ef"
   TileWidth: 150
   TileHeight: 150
-- DotDesktopFilePath: "/usr/share/applications/org.kde.index.desktop"
+- DotDesktopFilePath: "org.kde.index.desktop"
   TileColor: "#0050ef"
   TileWidth: 310
   TileHeight: 150
-- DotDesktopFilePath: "/usr/share/applications/org.kde.discover.desktop"
+- DotDesktopFilePath: "org.kde.discover.desktop"
   TileColor: "#0050ef"
   TileWidth: 150
   TileHeight: 150
-- DotDesktopFilePath: "/usr/share/applications/htop.desktop"
+- DotDesktopFilePath: "htop.desktop"
   TileColor: "#0050ef"
   TileWidth: 70
   TileHeight: 70
-- DotDesktopFilePath: "/usr/share/applications/org.kde.kalk.desktop"
+- DotDesktopFilePath: "org.kde.kalk.desktop"
   TileColor: "#0050ef"
   TileWidth: 70
   TileHeight: 70
-- DotDesktopFilePath: "/usr/share/applications/org.kde.nota.desktop"
+- DotDesktopFilePath: "org.kde.nota.desktop"
   TileColor: "#0050ef"
   TileWidth: 70
   TileHeight: 70
-- DotDesktopFilePath: "/usr/share/applications/org.kde.phone.dialer.desktop"
+- DotDesktopFilePath: "org.kde.phone.dialer.desktop"
   TileColor: "Red"
   TileWidth: 70
   TileHeight: 70
-- DotDesktopFilePath: "/usr/share/applications/org.kde.okular.desktop"
+- DotDesktopFilePath: "org.kde.okular.desktop"
   TileColor: "#0050ef"
   TileWidth: 150
   TileHeight: 150

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/tileslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/tileslist.py
@@ -51,6 +51,14 @@ def saveTilesList(tilesList):
 	# Define a list we'll use to store the dictionary in.
 	TilesListToSave = []
 	
+	# Set the root path to the .desktop files.
+		# TODO: Figure out how this can be used to get the .desktop
+		# files in the user's home folder.
+	if sys.platform.startswith("win32"):
+		DotDesktopRootPath = "C:\\Users\\drewn\\Desktop\\"
+	else:
+		DotDesktopRootPath = "/usr/share/applications/"
+	
 	# Loop through the list of dictionaries and append to
 	# the list using what's in each dictionary.
 	# Context for how we're getting the items appended:
@@ -63,7 +71,7 @@ def saveTilesList(tilesList):
 		# Add to the TilesListToSave.
 		# NOTE: QML won't give us integers for tile widths and heights,
 		# so we need to make them into integers in Python.
-		TilesListToSave.append({"DotDesktopFilePath": i["DotDesktopFilePath"], "TileWidth": int(i["TileWidth"]), "TileHeight": int(i["TileHeight"]), "TileColor": i["TileColor"]})
+		TilesListToSave.append({"DotDesktopFilePath": DotDesktopRootPath + i["DotDesktopFilePath"], "TileWidth": int(i["TileWidth"]), "TileHeight": int(i["TileHeight"]), "TileColor": i["TileColor"]})
 		# print(i["DotDesktopFilePath"])
 		
 	# print(TilesListToSave)

--- a/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/tileslist.py
+++ b/RetiledStart/PyRetiledStart/libs/libRetiledStartPy/tileslist.py
@@ -51,14 +51,6 @@ def saveTilesList(tilesList):
 	# Define a list we'll use to store the dictionary in.
 	TilesListToSave = []
 	
-	# Set the root path to the .desktop files.
-		# TODO: Figure out how this can be used to get the .desktop
-		# files in the user's home folder.
-	if sys.platform.startswith("win32"):
-		DotDesktopRootPath = "C:\\Users\\drewn\\Desktop\\"
-	else:
-		DotDesktopRootPath = "/usr/share/applications/"
-	
 	# Loop through the list of dictionaries and append to
 	# the list using what's in each dictionary.
 	# Context for how we're getting the items appended:
@@ -71,7 +63,7 @@ def saveTilesList(tilesList):
 		# Add to the TilesListToSave.
 		# NOTE: QML won't give us integers for tile widths and heights,
 		# so we need to make them into integers in Python.
-		TilesListToSave.append({"DotDesktopFilePath": DotDesktopRootPath + i["DotDesktopFilePath"], "TileWidth": int(i["TileWidth"]), "TileHeight": int(i["TileHeight"]), "TileColor": i["TileColor"]})
+		TilesListToSave.append({"DotDesktopFilePath": i["DotDesktopFilePath"], "TileWidth": int(i["TileWidth"]), "TileHeight": int(i["TileHeight"]), "TileColor": i["TileColor"]})
 		# print(i["DotDesktopFilePath"])
 		
 	# print(TilesListToSave)

--- a/RetiledStart/PyRetiledStart/main.py
+++ b/RetiledStart/PyRetiledStart/main.py
@@ -121,6 +121,7 @@ class TilesListViewModel(QObject):
 			# putting one in their home directory.
 			# This needs to be done for both the All Apps list as well as the Tiles.
 			#AppsList.RunApp("C:\\Users\\drewn\\Desktop\\" + ViewModelExecFilename)
+			# As it turns out, I guess I did need the path on Windows after all, or maybe I didn't.
 		AppsList.RunApp(ViewModelExecFilename)
 		# else:
 			#AppsList.RunApp("/usr/share/applications/" + ViewModelExecFilename)

--- a/RetiledStart/PyRetiledStart/main.py
+++ b/RetiledStart/PyRetiledStart/main.py
@@ -104,33 +104,6 @@ class AllAppsListItems(QObject):
 	# that there are null items after closing.
 	
 class TilesListViewModel(QObject):
-	@Slot(str)
-	def RunApp(self, ViewModelExecFilename):
-		# Pass the app's command to the code to actually
-		# figure out how to run it.
-		# This is different on Windows for debugging purposes.
-		# Example code for sys.platform:
-		# https://docs.python.org/3/library/sys.html#sys.platform
-		# if sys.platform.startswith("win32"):
-			# Not sure if this code here is a good idea, as any tiles on Windows
-			# are just going to have the path of the .desktop file, which is how
-			# it works on Linux.
-			# TODO: Figure out how to use the user's own copy of a .desktop
-			# file if it exists instead of the one from /usr/share/applications/,
-			# as this will allow the user to override the .desktop file by
-			# putting one in their home directory.
-			# This needs to be done for both the All Apps list as well as the Tiles.
-			#AppsList.RunApp("C:\\Users\\drewn\\Desktop\\" + ViewModelExecFilename)
-			# As it turns out, I guess I did need the path on Windows after all, or maybe I didn't.
-		AppsList.RunApp(ViewModelExecFilename)
-		# else:
-			#AppsList.RunApp("/usr/share/applications/" + ViewModelExecFilename)
-		# AppsList.RunApp(ViewModelExecFilename)
-		# I got rid of the if statement because it's basically redundant.
-		# Don't have both of the lines calling the running code uncommented
-		# at the same time like I did, or you'll be confused why it opens
-		# a GUI app twice but not, say, htop or nano.
-		
 	# Save the tile layout after exiting global exit mode.
 	# This involves reading JSON as a dictionary and
 	# modifying the startlayout.yaml file after copying

--- a/RetiledStart/PyRetiledStart/main.py
+++ b/RetiledStart/PyRetiledStart/main.py
@@ -68,13 +68,10 @@ class AllAppsListViewModel(QObject):
 	# https://stackoverflow.com/a/36210838
 	def GetDesktopEntryNameKey(self, DotDesktopFile):
 		# Get and return the .desktop file's Name key value.
-		# This is different on Windows for debugging purposes.
-		# Example code for sys.platform:
-		# https://docs.python.org/3/library/sys.html#sys.platform
-		if sys.platform.startswith("win32"):
-			return AppsList.GetAppName("C:\\Users\\drewn\\Desktop\\" + DotDesktopFile)
-		else:
-			return AppsList.GetAppName("/usr/share/applications/" + DotDesktopFile)
+		# We're no longer specifying the path here so to
+		# reduce code duplication, as this is also used when
+		# loading the tiles list.
+		return AppsList.GetAppName(DotDesktopFile)
 	
 	# Pin the app to Start.
 	@Slot(str)

--- a/RetiledStart/PyRetiledStart/pages/AllApps.qml
+++ b/RetiledStart/PyRetiledStart/pages/AllApps.qml
@@ -140,7 +140,10 @@ import "../../../RetiledStyles" as RetiledStyles
 								onClicked: allAppsListViewModel.RunApp(model.display)
 								// Set pin to start stuff.
 								dotDesktopFilePath: model.display
-								onPinToStart: allAppsListViewModel.PinToStart(model.display)
+								onPinToStart: {
+									// Visually pin the tile to start, then save the layout.
+									allAppsListViewModel.PinToStart(model.display);
+								}
 								//onClicked: allAppsListViewModel.RunApp("/usr/share/applications/" + dotDesktopFile)
 								} // End of the Button delegate item in the listview.
 			} // End of the Column that's the ListView's delegate.

--- a/RetiledStart/PyRetiledStart/pages/AllApps.qml
+++ b/RetiledStart/PyRetiledStart/pages/AllApps.qml
@@ -143,7 +143,6 @@ import "../../../RetiledStyles" as RetiledStyles
 								onPinToStart: {
 									// Visually pin the tile to start, then save the layout.
 									tilesContainer.pinToStart(model.display);
-									console.log(model.display);
 									// allAppsListViewModel.PinToStart(model.display);
 								}
 								//onClicked: allAppsListViewModel.RunApp("/usr/share/applications/" + dotDesktopFile)

--- a/RetiledStart/PyRetiledStart/pages/AllApps.qml
+++ b/RetiledStart/PyRetiledStart/pages/AllApps.qml
@@ -142,7 +142,8 @@ import "../../../RetiledStyles" as RetiledStyles
 								dotDesktopFilePath: model.display
 								onPinToStart: {
 									// Visually pin the tile to start, then save the layout.
-									allAppsListViewModel.PinToStart(model.display);
+									tilesContainer.pinToStart(model.display);
+									// allAppsListViewModel.PinToStart(model.display);
 								}
 								//onClicked: allAppsListViewModel.RunApp("/usr/share/applications/" + dotDesktopFile)
 								} // End of the Button delegate item in the listview.

--- a/RetiledStart/PyRetiledStart/pages/AllApps.qml
+++ b/RetiledStart/PyRetiledStart/pages/AllApps.qml
@@ -143,6 +143,7 @@ import "../../../RetiledStyles" as RetiledStyles
 								onPinToStart: {
 									// Visually pin the tile to start, then save the layout.
 									tilesContainer.pinToStart(model.display);
+									console.log(model.display);
 									// allAppsListViewModel.PinToStart(model.display);
 								}
 								//onClicked: allAppsListViewModel.RunApp("/usr/share/applications/" + dotDesktopFile)

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -242,8 +242,8 @@ ApplicationWindow {
 				
 				// Set up the tile click signals.
 				function tileClicked(execKey) {
-					// tilesListViewModel.RunApp(execKey);
-					console.log(execKey);
+					allAppsListViewModel.RunApp(execKey);
+					// console.log(execKey);
 				}
 				
 				// Pinning a tile to start.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -242,7 +242,8 @@ ApplicationWindow {
 				
 				// Set up the tile click signals.
 				function tileClicked(execKey) {
-					tilesListViewModel.RunApp(execKey);
+					// tilesListViewModel.RunApp(execKey);
+					console.log(execKey);
 				}
 				
 				// Pinning a tile to start.
@@ -270,6 +271,7 @@ ApplicationWindow {
 						// Turns out it was trying to run Firefox. Not sure how to stop that.
 						// Actually, I think this involves an event handler:
 						// https://stackoverflow.com/a/22605752
+						// For some reason, the entire path isn't being set on Windows.
 							NewTileObject.execKey = dotDesktopFilePath;
 						
 						// Set the .desktop file path for unpinning or resizing.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -277,7 +277,9 @@ ApplicationWindow {
 							NewTileObject.dotDesktopFilePath = dotDesktopFilePath;
 						
 						// Set tile index for the edit mode.
-							NewTileObject.tileIndex = i
+						// We're setting the tile's index to the pinned tiles count
+						// because it was already incremented earlier.
+							NewTileObject.tileIndex = pinnedTilesCount;
 						
 						// Connect clicked signal.
 							NewTileObject.clicked.connect(tileClicked);

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -271,10 +271,10 @@ ApplicationWindow {
 						// Turns out it was trying to run Firefox. Not sure how to stop that.
 						// Actually, I think this involves an event handler:
 						// https://stackoverflow.com/a/22605752
-							NewTileObject.execKey = ParsedTilesList[i].DotDesktopFilePath;
+							NewTileObject.execKey = dotDesktopFilePath;
 						
 						// Set the .desktop file path for unpinning or resizing.
-							NewTileObject.dotDesktopFilePath = ParsedTilesList[i].DotDesktopFilePath;
+							NewTileObject.dotDesktopFilePath = dotDesktopFilePath;
 						
 						// Set tile index for the edit mode.
 							NewTileObject.tileIndex = i

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -296,12 +296,14 @@ ApplicationWindow {
 						// Connect decrementing the pinned tiles count signal.
 							NewTileObject.decrementPinnedTilesCount.connect(checkPinnedTileCount);
 							
+							// Increment the tile count and go back to the tiles page.
+							checkPinnedTileCount(1, true);
+							
 							// Exit global edit mode so we save the newly-pinned tile
 							// to the layout config file.
 							toggleGlobalEditMode(false, true);
 							
-							// Increment the tile count and go back to the tiles page.
-							checkPinnedTileCount(1, true);
+							
 				}
 				
 				// Turn on or off global edit mode.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -298,13 +298,16 @@ ApplicationWindow {
 						// Connect decrementing the pinned tiles count signal.
 							NewTileObject.decrementPinnedTilesCount.connect(checkPinnedTileCount);
 							
+							// Force the layout of the tiles list:
+							// https://doc.qt.io/qt-5/qml-qtquick-flow.html#forceLayout-method
+							tilesContainer.forceLayout();
+							
 							// Increment the tile count and go back to the tiles page.
 							checkPinnedTileCount(1, true);
 							
 							// Exit global edit mode so we save the newly-pinned tile
 							// to the layout config file.
 							toggleGlobalEditMode(false, true);
-							
 							
 				}
 				

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -255,7 +255,7 @@ ApplicationWindow {
 					var TileComponent = Qt.createComponent("../../../RetiledStyles/Tile.qml");
 					
 					var NewTileObject = TileComponent.createObject(tilesContainer);
-						// Increment the tile count.
+						// Increment the tile count and go back to the tiles page.
 							checkPinnedTileCount(1, true);
 						// Set tile properties.
 							NewTileObject.tileText = allAppsListViewModel.GetDesktopEntryNameKey(dotDesktopFilePath);
@@ -298,6 +298,10 @@ ApplicationWindow {
 						
 						// Connect decrementing the pinned tiles count signal.
 							NewTileObject.decrementPinnedTilesCount.connect(checkPinnedTileCount);
+							
+							// Exit global edit mode so we save the newly-pinned tile
+							// to the layout config file.
+							toggleGlobalEditMode(false, true);
 				}
 				
 				// Turn on or off global edit mode.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -255,8 +255,7 @@ ApplicationWindow {
 					var TileComponent = Qt.createComponent("../../../RetiledStyles/Tile.qml");
 					
 					var NewTileObject = TileComponent.createObject(tilesContainer);
-						// Increment the tile count and go back to the tiles page.
-							checkPinnedTileCount(1, true);
+						
 						// Set tile properties.
 							NewTileObject.tileText = allAppsListViewModel.GetDesktopEntryNameKey(dotDesktopFilePath);
 							NewTileObject.width = 150;
@@ -277,9 +276,7 @@ ApplicationWindow {
 							NewTileObject.dotDesktopFilePath = dotDesktopFilePath;
 						
 						// Set tile index for the edit mode.
-						// We're setting the tile's index to the pinned tiles count
-						// because it was already incremented earlier.
-							NewTileObject.tileIndex = pinnedTilesCount;
+							NewTileObject.tileIndex = pinnedTilesCount + 1;
 						
 						// Connect clicked signal.
 							NewTileObject.clicked.connect(tileClicked);
@@ -302,6 +299,9 @@ ApplicationWindow {
 							// Exit global edit mode so we save the newly-pinned tile
 							// to the layout config file.
 							toggleGlobalEditMode(false, true);
+							
+							// Increment the tile count and go back to the tiles page.
+							checkPinnedTileCount(1, true);
 				}
 				
 				// Turn on or off global edit mode.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -259,9 +259,13 @@ ApplicationWindow {
 							checkPinnedTileCount(1, true);
 						// Set tile properties.
 							NewTileObject.tileText = allAppsListViewModel.GetDesktopEntryNameKey(dotDesktopFilePath);
-							NewTileObject.width = ParsedTilesList[i].TileWidth;
-							NewTileObject.height = ParsedTilesList[i].TileHeight;
-							NewTileObject.tileBackgroundColor = ParsedTilesList[i].TileColor;
+							NewTileObject.width = 150;
+							NewTileObject.height = 150;
+							// TODO: Add another property to tiles so they'll default to
+							// using accent colors unless the boolean to use accent colors
+							// is off, in which case they'll use a specified tile background
+							// color according to the layout config file or the .desktop file.
+							NewTileObject.tileBackgroundColor = "#0050ef";
 						// Doesn't quite work on Windows because the hardcoded tile is trying to read
 						// from /usr/share/applications and can't find Firefox.
 						// Turns out it was trying to run Firefox. Not sure how to stop that.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -258,7 +258,7 @@ ApplicationWindow {
 						// Increment the tile count.
 							checkPinnedTileCount(1, true);
 						// Set tile properties.
-							NewTileObject.tileText = ParsedTilesList[i].TileAppNameAreaText;
+							NewTileObject.tileText = allAppsListViewModel.GetDesktopEntryNameKey(dotDesktopFilePath);
 							NewTileObject.width = ParsedTilesList[i].TileWidth;
 							NewTileObject.height = ParsedTilesList[i].TileHeight;
 							NewTileObject.tileBackgroundColor = ParsedTilesList[i].TileColor;

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -245,6 +245,15 @@ ApplicationWindow {
 					tilesListViewModel.RunApp(execKey);
 				}
 				
+				// Pinning a tile to start.
+				function pinToStart(dotDesktopFilePath) {
+					// Create a new tile using the .desktop file path.
+					// Copied from the other code that adds tiles on
+					// startup because this hasn't been separated yet.
+					// TODO: Put the code to create tiles into its own
+					// function to reduce code duplication.
+				}
+				
 				// Turn on or off global edit mode.
 				function toggleGlobalEditMode(enable, showAllAppsButtonAndAllowGoingBetweenPages) {
 					// If enable is false, global edit mode will be

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -351,14 +351,14 @@ ApplicationWindow {
 								allAppsButton.visible = true;
 							// Reset the Back button/Escape key shortcut.
 								backButtonShortcut.enabled = true;
-							// } else if ((startScreenView.interactive == true) && (startScreenView.currentIndex == 1)) {
-								// // Move to the bottom of the tiles list, as we're pinning a tile:
-								// // https://stackoverflow.com/a/25363306
-								// // As it turns out, you have to use the flickable's values
-								// // for both contentHeight and height in order for this to work,
-								// // or it won't be the right position.
-								// tilesFlickable.contentY = tilesFlickable.contentHeight-tilesFlickable.height;
-								// startScreenView.currentIndex = 0;
+							} else if ((startScreenView.interactive == true) && (startScreenView.currentIndex == 1)) {
+								// Move to the bottom of the tiles list, as we're pinning a tile:
+								// https://stackoverflow.com/a/25363306
+								// As it turns out, you have to use the flickable's values
+								// for both contentHeight and height in order for this to work,
+								// or it won't be the right position.
+								tilesFlickable.contentY = tilesFlickable.contentHeight-tilesFlickable.height;
+								startScreenView.currentIndex = 0;
 								// Not sure if this code will help when I'm trying to figure out
 								// moving to the bottom to pin tiles.
 							} // End of if statement seeing if the swipeview is currently interactive.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -309,6 +309,10 @@ ApplicationWindow {
 							// to the layout config file.
 							toggleGlobalEditMode(false, true);
 							
+							// Force the layout of the tiles list:
+							// https://doc.qt.io/qt-5/qml-qtquick-flow.html#forceLayout-method
+							tilesContainer.forceLayout();
+							
 				}
 				
 				// Turn on or off global edit mode.

--- a/RetiledStart/PyRetiledStart/pages/Tiles.qml
+++ b/RetiledStart/PyRetiledStart/pages/Tiles.qml
@@ -252,6 +252,46 @@ ApplicationWindow {
 					// startup because this hasn't been separated yet.
 					// TODO: Put the code to create tiles into its own
 					// function to reduce code duplication.
+					var TileComponent = Qt.createComponent("../../../RetiledStyles/Tile.qml");
+					
+					var NewTileObject = TileComponent.createObject(tilesContainer);
+						// Increment the tile count.
+							checkPinnedTileCount(1, true);
+						// Set tile properties.
+							NewTileObject.tileText = ParsedTilesList[i].TileAppNameAreaText;
+							NewTileObject.width = ParsedTilesList[i].TileWidth;
+							NewTileObject.height = ParsedTilesList[i].TileHeight;
+							NewTileObject.tileBackgroundColor = ParsedTilesList[i].TileColor;
+						// Doesn't quite work on Windows because the hardcoded tile is trying to read
+						// from /usr/share/applications and can't find Firefox.
+						// Turns out it was trying to run Firefox. Not sure how to stop that.
+						// Actually, I think this involves an event handler:
+						// https://stackoverflow.com/a/22605752
+							NewTileObject.execKey = ParsedTilesList[i].DotDesktopFilePath;
+						
+						// Set the .desktop file path for unpinning or resizing.
+							NewTileObject.dotDesktopFilePath = ParsedTilesList[i].DotDesktopFilePath;
+						
+						// Set tile index for the edit mode.
+							NewTileObject.tileIndex = i
+						
+						// Connect clicked signal.
+							NewTileObject.clicked.connect(tileClicked);
+						
+						// Connect global edit mode toggle.
+							NewTileObject.toggleGlobalEditMode.connect(toggleGlobalEditMode);
+						
+						// Connect hideEditModeControlsOnPreviousTile signal.
+							NewTileObject.hideEditModeControlsOnPreviousTile.connect(hideEditModeControlsOnPreviousTile);
+						
+						// Connect the opacity-setter function.
+							NewTileObject.setTileOpacity.connect(setTileOpacity);
+						
+						// Connect long-press signal.
+						// NewTileObject.pressAndHold.connect(tileLongPressed);
+						
+						// Connect decrementing the pinned tiles count signal.
+							NewTileObject.decrementPinnedTilesCount.connect(checkPinnedTileCount);
 				}
 				
 				// Turn on or off global edit mode.

--- a/RetiledStyles/AllAppsListEntry.qml
+++ b/RetiledStyles/AllAppsListEntry.qml
@@ -122,7 +122,11 @@ RetiledStyles.Button {
 				// than it does in the search app, even
 				// though the button template uses the
 				// same weight for each.
-				onClicked: pinToStart(dotDesktopFilePath)
+				onClicked: {
+					// Hide the context menu.
+					allappscontextmenu.visible = false;
+					pinToStart(dotDesktopFilePath);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Tiles can now be pinned to Start. There are some issues with this in that if you unpin all the tiles, you'll have to resize the second tile you pin so that it goes to the right of the first tile, otherwise they'll just go in a single column. Tried to fix it, but that may require more effort. I'd recommend deleting any modified start layout config files and just put your changes back, as the paths for the .desktop files in the default file have been removed so that it's easier to get the path when loading user-pinned tiles. I'm sorry for any inconvenience this may cause, but it'll allow the user to edit a .desktop file and store it in their home folder so it overrides the default one once that's implemented.

After this, the last things I need to do are to ensure a tile isn't already pinned before pinning it, as well as do all the last style changes that need to be done before v0.1 DP1.