### PR TITLE
All Apps list context menu style.

### DIFF
--- a/RetiledStyles/AllAppsListEntry.qml
+++ b/RetiledStyles/AllAppsListEntry.qml
@@ -116,6 +116,9 @@ RetiledStyles.Button {
 			// }
 			RetiledStyles.Button {
 				width: parent.width
+				textColor: "black"
+				borderColor: "transparent"
+				pressedBackgroundColor: "transparent"
 				text: qsTr("pin to start")
 				// TODO: Figure out why the font
 				// on this button looks way more bold

--- a/RetiledStyles/AllAppsListEntry.qml
+++ b/RetiledStyles/AllAppsListEntry.qml
@@ -77,7 +77,7 @@ RetiledStyles.Button {
 	// Here's how to do it dynamically, which might help with
 	// the tiles:
 	// https://stackoverflow.com/a/45052339
-	Popup {
+	ContextMenu {
 		id: allappscontextmenu
 		width: window.width
 		contentWidth: window.width

--- a/RetiledStyles/AllAppsListEntry.qml
+++ b/RetiledStyles/AllAppsListEntry.qml
@@ -117,12 +117,12 @@ RetiledStyles.Button {
 			
 			// Another spacer item above.
 			Item {
-				height: 5
-				width: parent.width
+				height: 17
+				width: window.width
 			}
 			
 			ContextMenuButton {
-				width: parent.width
+				width: window.width
 				textColor: "black"
 				borderColor: "transparent"
 				pressedBackgroundColor: "transparent"
@@ -142,8 +142,8 @@ RetiledStyles.Button {
 			// Add a spacer item at the bottom.
 			// Not sure why it's there in WP, but I guess it looks better.
 			Item {
-				height: 50
-				width: parent.width
+				height: 62
+				width: window.width
 			}
 		}
 	}

--- a/RetiledStyles/AllAppsListEntry.qml
+++ b/RetiledStyles/AllAppsListEntry.qml
@@ -131,6 +131,13 @@ RetiledStyles.Button {
 					pinToStart(dotDesktopFilePath);
 				}
 			}
+			
+			// Add a spacer item at the bottom.
+			// Not sure why it's there in WP, but I guess it looks better.
+			Item {
+				height: 50
+				width: parent.width
+			}
 		}
 	}
 	

--- a/RetiledStyles/AllAppsListEntry.qml
+++ b/RetiledStyles/AllAppsListEntry.qml
@@ -114,6 +114,13 @@ RetiledStyles.Button {
 				// font.weight: Font.Normal
 				// onClicked: pinToStart(dotDesktopFilePath)
 			// }
+			
+			// Another spacer item above.
+			Item {
+				height: 5
+				width: parent.width
+			}
+			
 			ContextMenuButton {
 				width: parent.width
 				textColor: "black"

--- a/RetiledStyles/AllAppsListEntry.qml
+++ b/RetiledStyles/AllAppsListEntry.qml
@@ -114,7 +114,7 @@ RetiledStyles.Button {
 				// font.weight: Font.Normal
 				// onClicked: pinToStart(dotDesktopFilePath)
 			// }
-			RetiledStyles.Button {
+			ContextMenuButton {
 				width: parent.width
 				textColor: "black"
 				borderColor: "transparent"

--- a/RetiledStyles/ContextMenu.qml
+++ b/RetiledStyles/ContextMenu.qml
@@ -1,0 +1,64 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 The Qt Company Ltd.
+** Contact: http://www.qt.io/licensing/
+**
+** This file is part of the Qt Quick Controls 2 module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL3$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see http://www.qt.io/terms-conditions. For further
+** information use the contact form at http://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or later as published by the Free
+** Software Foundation and appearing in the file LICENSE.GPL included in
+** the packaging of this file. Please review the following information to
+** ensure the GNU General Public License version 2.0 requirements will be
+** met: http://www.gnu.org/licenses/gpl-2.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+import QtQuick
+import QtQuick.Templates as T
+import QtQuick.Controls.Universal
+
+T.Popup {
+    id: control
+
+    implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset,
+                            contentWidth + leftPadding + rightPadding)
+    implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
+                             contentHeight + topPadding + bottomPadding)
+
+    padding: 12
+
+    background: Rectangle {
+        color: control.Universal.chromeMediumLowColor
+        border.color: control.Universal.chromeHighColor
+        border.width: 1 // FlyoutBorderThemeThickness
+    }
+
+    T.Overlay.modal: Rectangle {
+        color: control.Universal.baseLowColor
+    }
+
+    T.Overlay.modeless: Rectangle {
+        color: control.Universal.baseLowColor
+    }
+}

--- a/RetiledStyles/ContextMenu.qml
+++ b/RetiledStyles/ContextMenu.qml
@@ -77,16 +77,16 @@ T.Popup {
     padding: 12
 
     background: Rectangle {
-        color: control.Universal.chromeMediumLowColor
-        border.color: control.Universal.chromeHighColor
+        color: "white"
+        border.color: "black"
         border.width: 1 // FlyoutBorderThemeThickness
     }
 
     T.Overlay.modal: Rectangle {
-        color: control.Universal.baseLowColor
+        color: "transparent"
     }
 
     T.Overlay.modeless: Rectangle {
-        color: control.Universal.baseLowColor
+        color: "transparent"
     }
 }

--- a/RetiledStyles/ContextMenu.qml
+++ b/RetiledStyles/ContextMenu.qml
@@ -74,7 +74,7 @@ T.Popup {
     implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
                              contentHeight + topPadding + bottomPadding)
 
-    padding: 12
+    padding: 0
 
     background: Rectangle {
         color: "white"

--- a/RetiledStyles/ContextMenu.qml
+++ b/RetiledStyles/ContextMenu.qml
@@ -34,6 +34,34 @@
 **
 ****************************************************************************/
 
+// RetiledStyles - Windows Phone 8.x-like QML styles for the
+//                 Retiled project. Some code was copied from
+//                 the official qtdeclarative repo, which you can
+//                 access a copy of here:
+//                 https://github.com/DrewNaylor/qtdeclarative
+// Modifications to this file are Copyright (C) 2021 Drew Naylor
+// Please refer to The Qt Company's copyrights above
+// for the copyrights to the original file.
+// (Note that the copyright years include the years left out by the hyphen.)
+// Windows Phone and all other related copyrights and trademarks are property
+// of Microsoft Corporation. All rights reserved.
+//
+// This file was modified from the original QtQuick Controls source.
+// In particular, I took code from the Universal style's "Button.qml" file.
+// You can get a copy of the source from here:
+// https://github.com/DrewNaylor/qtdeclarative
+//
+// This file is a part of the RetiledStyles project, which is used by Retiled.
+// Neither Retiled nor Drew Naylor are associated with Microsoft
+// and Microsoft does not endorse Retiled.
+// Any other copyrights and trademarks belong to their
+// respective people and companies/organizations.
+//
+//
+//   Please refer to the licensing info above for the licenses this file falls
+//   under.
+
+
 import QtQuick
 import QtQuick.Templates as T
 import QtQuick.Controls.Universal

--- a/RetiledStyles/ContextMenuButton.qml
+++ b/RetiledStyles/ContextMenuButton.qml
@@ -131,8 +131,8 @@ ButtonBase {
 				// don't get too out of control.
 				font.letterSpacing: -0.8 * scaleFactor
 				// Set font.
-				font.family: "Open Sans SemiBold"
-				font.weight: Font.DemiBold
+				font.family: "Open Sans"
+				font.weight: Font.Normal
             }
 			
 		// Had to use the contentItem Text thing to change stuff from the "customizing button"

--- a/RetiledStyles/ContextMenuButton.qml
+++ b/RetiledStyles/ContextMenuButton.qml
@@ -51,7 +51,7 @@ ButtonBase {
 	// https://docs.microsoft.com/en-us/previous-versions/windows/apps/ff769552(v=vs.105)#font-sizes
 	// That's too big, let's use 20.
 	// Nah, 18.
-	property int fontSize: 16
+	property int fontSize: 18
 	// textColor would usually be white, but it can be
 	// changed to black. Actually, maybe adding a way to
 	// automatically set the theme with a boolean would

--- a/RetiledStyles/ContextMenuButton.qml
+++ b/RetiledStyles/ContextMenuButton.qml
@@ -1,0 +1,227 @@
+// RetiledStyles - Windows Phone 8.x-like QML styles for the
+//                 Retiled project. Some code was copied from
+//                 the official qtdeclarative repo, which you can
+//                 access a copy of here:
+//                 https://github.com/DrewNaylor/qtdeclarative
+// Copyright (C) 2021 Drew Naylor
+// (Note that the copyright years include the years left out by the hyphen.)
+// Windows Phone and all other related copyrights and trademarks are property
+// of Microsoft Corporation. All rights reserved.
+//
+// This file is a part of the RetiledStyles project, which is used by Retiled.
+// Neither Retiled nor Drew Naylor are associated with Microsoft
+// and Microsoft does not endorse Retiled.
+// Any other copyrights and trademarks belong to their
+// respective people and companies/organizations.
+//
+//
+//    RetiledStyles is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License
+//    version 3 as published by the Free Software Foundation.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Tried to do import ButtonBase but QML said
+// the style wasn't installed, so I'm just
+// importing everything in this folder
+// until I can figure out a better solution.
+import "."
+import QtQuick
+
+// Change the button so it's more like WP.
+// I took these properties from the button
+// in RetiledSearch.
+ButtonBase {
+	
+	id: control
+	
+	// Usually buttons have text, but if they're images,
+	// I'd have to figure something out.
+	// Setting this to 25 because the WP ButtonBase used it:
+	// https://github.com/microsoftarchive/WindowsPhoneToolkit/blob/master/PhoneToolkitSample8/App.xaml#L51
+	// Or at least, I hope it did and the sample is being accurate.
+	// "PhoneFontSizeMediumLarge" is a double at 25.333, but
+	// we need to use an integer:
+	// https://docs.microsoft.com/en-us/previous-versions/windows/apps/ff769552(v=vs.105)#font-sizes
+	// That's too big, let's use 20.
+	// Nah, 18.
+	property int fontSize: 16
+	// textColor would usually be white, but it can be
+	// changed to black. Actually, maybe adding a way to
+	// automatically set the theme with a boolean would
+	// be useful.
+	property string textColor: "white"
+	// pressedBackgroundColor will usually be the accent color.
+	property string pressedBackgroundColor: "#0050ef"
+	// unpressedBackgroundColor is usually transparent,
+	// but it may be useful to specify a color, such as for
+	// tiles.
+	property string unpressedBackgroundColor: "transparent"
+	// Just like the textColor, borderColor would be black
+	// in the light theme.
+	property string borderColor: "white"
+	// Very rarely, buttons will have a different border color
+	// when pressed. One example of this is the "unpin tile"
+	// button. I still need to check the light theme for this.
+	property string pressedBorderColor: "white"
+	property int borderWidth: 2
+	property int borderRadius: 0
+	// Change button size to help with the large font.
+	property int buttonWidth: 100
+	property int buttonHeight: 40
+	
+	// Properties for pixel density:
+	// https://stackoverflow.com/a/38003760
+	// This is what QML told me when I used
+	// console.log(Screen.pixelDensity).
+	property real mylaptopPixelDensity: 4.4709001084468
+	// This is just whatever the device that's running will use.
+	property real scaleFactor: Screen.pixelDensity / mylaptopPixelDensity
+	
+	
+	//// Set the default state.
+     // state: "RELEASED"
+	
+	contentItem: Text {
+		// I couldn't figure out why things weren't
+		// working, but it turns out that you can't
+		// have another contentItem in the button in
+		// the window or it'll override this style's
+		// // contentItem.
+                horizontalAlignment: Text.AlignLeft
+				// It's not perfectly in the vertical center,
+				// but it's close enough I think.
+				// At least the horizontalAlignment works
+				// better when using buttonWidth.
+                verticalAlignment: Text.AlignVCenter
+				// Make the font bigger.
+				// pixelSize isn't device-independent.
+                font.pointSize: control.fontSize
+                text: control.text
+                color: control.textColor
+				// Qt's docs say to set the text to the width
+				// of the parent to get proper centered text,
+				// but it doesn't seem to work.
+				width: buttonWidth
+				height: buttonHeight
+				// A letter spacing of -0.8 emulates
+				// Segoe WP's letter spacing.
+				// However, it's not perfect as I can't
+				// get the second "l" in "really" to be
+				// in half in a medium tile at the same time
+				// as the entirety of the "o" in "Calculator"
+				// is showing on a small tile.
+				// For some reason, the font spacing is slightly
+				// off on the phone.
+				// I think they're different because this is
+				// based on pixels.
+				// Preferably this would multiply against
+				// the DPI to determine what number should be used.
+				// I think -1.25 is close enough for the PinePhone.
+				// This SO answer shows how to multiply against
+				// pixel density: https://stackoverflow.com/a/38003760
+				// This doesn't help that much, but I think
+				// I'll keep it for now to make sure things
+				// don't get too out of control.
+				font.letterSpacing: -0.8 * scaleFactor
+				// Set font.
+				font.family: "Open Sans SemiBold"
+				font.weight: Font.DemiBold
+            }
+			
+		// Had to use the contentItem Text thing to change stuff from the "customizing button"
+        // page in the QML docs here:
+        // https://doc.qt.io/qt-5/qtquickcontrols2-customize.html#customizing-button
+        // Also need to change the background and border.
+           background: Rectangle {
+                implicitWidth: control.buttonWidth
+                implicitHeight: control.buttonHeight
+                border.color: control.down ? control.pressedBorderColor : control.borderColor
+				// Set the background color for the button here
+				// since the state-changing thing doesn't work
+				// anymore in Qt6. This is temporary if I figure
+				// out how to fix the animation.
+				color: control.down ? control.pressedBackgroundColor : control.unpressedBackgroundColor
+                border.width: control.borderWidth
+                radius: control.borderRadius
+				
+				
+				//// I think this is the way I'll rotate and shrink the button
+                //// when it's held down:
+                //// https://doc.qt.io/qt-5/qml-qtquick-animation.html#running-prop
+                //// Better stuff on animations:
+                //// https://doc.qt.io/qt-5/qtquick-statesanimations-animations.html
+                //// Actually, this is what I needed:
+                //// https://doc.qt.io/qt-5/qml-qtquick-scaleanimator.html
+                //// Wait, this looks better, but is older so I hope it works:
+                //// https://forum.qt.io/topic/2712/animating-button-press
+                //// TODO: Figure out how to rotate the button toward where it's
+                //// pressed, like on WP. Maybe WinUI code will help me figure it
+                //// out for Avalonia, then I'll translate it to QML.
+
+
+                //// We're using MultiPointTouchArea to ensure this'll work with touch.
+                //MultiPointTouchArea {
+                //    anchors.fill: parent
+                 //   onPressed: searchButton.state = "PRESSED"
+                  //  onReleased: searchButton.state = "RELEASED"
+               // }
+
+                //// Set up the states.
+                //// Figure out how to change
+                //// the accent color in those style qml files based on what's in a config
+                //// file. Maybe I can use JS to read that file and get the user's accent color,
+                //// though that may not be possible. Hopefully there's something.
+				//// Actually, maybe Python could bind QML properties to the user's accent color
+				//// setting in a file.
+				//// TODO: Fix the button text so it's in the middle vertically and horizontally.
+				//// TODO: Fix this for PySide6/Qt6. For now I'm making the button change
+				//// its appearance when it's down, but it's not as smooth as these animations.
+              //  states: [
+                    //State {
+                    //    name: "PRESSED"
+                        //// Avalonia used 0.98, and I thought it looked bad in QML,
+                        //// but I think it's fine.
+                        //// We can actually just scale the whole button down rather than
+                        //// the rectangle we're in. Didn't know that, so I decided to see if
+                        //// QML allows that because that seems to be what Avalonia does,
+                        //// and it works.
+                       // PropertyChanges {target: searchButton; scale: 0.98}
+                        // Change the button background to Cobalt when pressed.
+                     //   PropertyChanges {target: searchButton; color: "#0050ef"}
+                   // },
+                    //// There's supposed to be a comma there.
+                 //   State {
+                      //  name: "RELEASED"
+                    //    PropertyChanges {target: searchButton; scale: 1.0}
+                  //      PropertyChanges {target: searchButton; color: "black"}
+                //    }
+              //  ]
+
+                //// Set up the transitions.
+              //  transitions: [
+                  //  Transition {
+                    //    from: "PRESSED"
+                     //   to: "RELEASED"
+                       // NumberAnimation { target: searchButton; duration: 60}
+                     //   ColorAnimation { target: searchButton; duration: 60}
+                   // },
+
+                    //Transition {
+                     //   from: "RELEASED"
+                     //   to: "PRESSED"
+                      //  NumberAnimation { target: searchButton; duration: 60}
+                    //    ColorAnimation { target: searchButton; duration: 60}
+                  //  }
+                
+                //]
+				
+		   }
+	
+}


### PR DESCRIPTION
Now the context menu that shows up when you long-press on an item in the All Apps list looks correct, except for the lack of a spacer on the left side of the context menu. I could spend time getting it there right now, but it looks good enough at the moment so I think I'll just wait right now. It would probably be easy if I added an empty Item to the left of a Text item in the customized context menu button instead of having it be like a standard button, but that's more effort and it looks good as it is. The sizing for the context menu and its spacing may be off too, but it's mostly the same as a screenshot I took a while back.