### PR TITLE
Modify appbar styles so they look right.

### DIFF
--- a/RetiledSearch/RetiledSearch/MainWindow.qml
+++ b/RetiledSearch/RetiledSearch/MainWindow.qml
@@ -211,7 +211,7 @@ ApplicationWindow {
         }
     }
 
-    Drawer {
+    RetiledStyles.AppBarDrawerBase {
     // TODO: Figure out a way to allow the drawer to be closed from any
     // page and not just from clicking inside the main page or clicking
     // on any of the items in the drawer.
@@ -246,9 +246,7 @@ ApplicationWindow {
 
         // Removing the shadow from the drawer:
         // https://stackoverflow.com/a/63411102
-        Overlay.modal: Rectangle {
-                  color: "transparent"
-              }
+        
 
        Rectangle {
        // You have to set this rectangle's color

--- a/RetiledSearch/RetiledSearch/MainWindow.qml
+++ b/RetiledSearch/RetiledSearch/MainWindow.qml
@@ -263,7 +263,7 @@ ApplicationWindow {
             clip: true
             focus: true
 
-            delegate: ItemDelegate {
+            delegate: RetiledStyles.AppBarDrawerEntry {
                 width: parent.width
                 text: model.title
                 onClicked: {

--- a/RetiledSearch/RetiledSearch/MainWindow.qml
+++ b/RetiledSearch/RetiledSearch/MainWindow.qml
@@ -156,7 +156,9 @@ ApplicationWindow {
             anchors.fill: parent
 
 
-            ToolButton {
+            RetiledStyles.AppBarMoreButton {
+			// Usually we won't use the AppBarMoreButton for items here,
+			// but the Back button can't have any visual changes.
 			id: backButton
 			visible: false
 			// QML with Python requires you use "file:" before

--- a/RetiledSearch/RetiledSearch/MainWindow.qml
+++ b/RetiledSearch/RetiledSearch/MainWindow.qml
@@ -142,7 +142,7 @@ ApplicationWindow {
 	// This is just whatever the device that's running will use.
 	property real scaleFactor: Screen.pixelDensity / mylaptopPixelDensity
 	
-	footer: ToolBar {
+	footer: RetiledStyles.AppBar {
 
                 id: appBar
 
@@ -227,7 +227,7 @@ ApplicationWindow {
         width: window.width
         // Set height to 50 so that the app bar always moves out of the way,
         // even when the window is taller or shorter.
-        height: 50
+        height: 55
 		// Not sure what Interactive means, but I'll guess it determines
 		// if you can interact with the app drawer.
         interactive: stackView.depth === 1

--- a/RetiledSearch/RetiledSearch/MainWindow.qml
+++ b/RetiledSearch/RetiledSearch/MainWindow.qml
@@ -193,7 +193,7 @@ ApplicationWindow {
                 Layout.fillWidth: true
             }
 			
-            ToolButton {
+            RetiledStyles.AppBarMoreButton {
 				id: appbarEllipsisButton
 				// TODO: Figure out a way to use SVG files because
 				// this is blurry with HiDPI.

--- a/RetiledStyles/AppBar.qml
+++ b/RetiledStyles/AppBar.qml
@@ -1,0 +1,53 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 The Qt Company Ltd.
+** Contact: http://www.qt.io/licensing/
+**
+** This file is part of the Qt Quick Controls 2 module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL3$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see http://www.qt.io/terms-conditions. For further
+** information use the contact form at http://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or later as published by the Free
+** Software Foundation and appearing in the file LICENSE.GPL included in
+** the packaging of this file. Please review the following information to
+** ensure the GNU General Public License version 2.0 requirements will be
+** met: http://www.gnu.org/licenses/gpl-2.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+import QtQuick
+import QtQuick.Templates as T
+import QtQuick.Controls.Universal
+
+T.ToolBar {
+    id: control
+
+    implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset,
+                            contentWidth + leftPadding + rightPadding)
+    implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
+                             contentHeight + topPadding + bottomPadding)
+
+    background: Rectangle {
+        implicitHeight: 48 // AppBarThemeCompactHeight
+        color: control.Universal.chromeMediumColor
+    }
+}

--- a/RetiledStyles/AppBar.qml
+++ b/RetiledStyles/AppBar.qml
@@ -34,6 +34,34 @@
 **
 ****************************************************************************/
 
+// RetiledStyles - Windows Phone 8.x-like QML styles for the
+//                 Retiled project. Some code was copied from
+//                 the official qtdeclarative repo, which you can
+//                 access a copy of here:
+//                 https://github.com/DrewNaylor/qtdeclarative
+// Modifications to this file are Copyright (C) 2021 Drew Naylor
+// Please refer to The Qt Company's copyrights above
+// for the copyrights to the original file.
+// (Note that the copyright years include the years left out by the hyphen.)
+// Windows Phone and all other related copyrights and trademarks are property
+// of Microsoft Corporation. All rights reserved.
+//
+// This file was modified from the original QtQuick Controls source.
+// In particular, I took code from the Universal style's "Button.qml" file.
+// You can get a copy of the source from here:
+// https://github.com/DrewNaylor/qtdeclarative
+//
+// This file is a part of the RetiledStyles project, which is used by Retiled.
+// Neither Retiled nor Drew Naylor are associated with Microsoft
+// and Microsoft does not endorse Retiled.
+// Any other copyrights and trademarks belong to their
+// respective people and companies/organizations.
+//
+//
+//   Please refer to the licensing info above for the licenses this file falls
+//   under.
+
+
 import QtQuick
 import QtQuick.Templates as T
 import QtQuick.Controls.Universal
@@ -45,6 +73,9 @@ T.ToolBar {
                             contentWidth + leftPadding + rightPadding)
     implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
                              contentHeight + topPadding + bottomPadding)
+
+	// Currently we're not using this file, but it'll be useful
+	// when setting up the light and dark theme changes.
 
     background: Rectangle {
         implicitHeight: 48 // AppBarThemeCompactHeight

--- a/RetiledStyles/AppBar.qml
+++ b/RetiledStyles/AppBar.qml
@@ -40,6 +40,7 @@
 //                 access a copy of here:
 //                 https://github.com/DrewNaylor/qtdeclarative
 // Modifications to this file are Copyright (C) 2021 Drew Naylor
+// and are licensed under the LGPLv3.
 // Please refer to The Qt Company's copyrights above
 // for the copyrights to the original file.
 // (Note that the copyright years include the years left out by the hyphen.)

--- a/RetiledStyles/AppBarDrawerBase.qml
+++ b/RetiledStyles/AppBarDrawerBase.qml
@@ -89,7 +89,10 @@ T.Drawer {
     exit: Transition { SmoothedAnimation { velocity: 5 } }
 
     background: Rectangle {
-        color: control.Universal.chromeMediumLowColor
+		// Change the color of the appbar background to be what it should be in dark mode.
+		// Source using a screenshot of the WP Store:
+		// https://stackoverflow.com/questions/19492344/how-to-add-normal-buttons-to-appbar-in-windows-phone-8
+        color: control.Universal.chromeMediumColor
         Rectangle {
             readonly property bool horizontal: control.edge === Qt.LeftEdge || control.edge === Qt.RightEdge
             width: horizontal ? 1 : parent.width

--- a/RetiledStyles/AppBarDrawerBase.qml
+++ b/RetiledStyles/AppBarDrawerBase.qml
@@ -101,10 +101,10 @@ T.Drawer {
     }
 
     T.Overlay.modal: Rectangle {
-        color: control.Universal.baseLowColor
+        color: "transparent"
     }
 
     T.Overlay.modeless: Rectangle {
-        color: control.Universal.baseLowColor
+        color: "transparent"
     }
 }

--- a/RetiledStyles/AppBarDrawerBase.qml
+++ b/RetiledStyles/AppBarDrawerBase.qml
@@ -85,9 +85,6 @@ T.Drawer {
     leftPadding: control.edge === Qt.RightEdge
     rightPadding: control.edge === Qt.LeftEdge
     bottomPadding: control.edge === Qt.TopEdge
-	
-	// Don't have it drag on the edge, because we're overriding this.
-	dragMargin: 0
 
     enter: Transition { SmoothedAnimation { velocity: 5 } }
     exit: Transition { SmoothedAnimation { velocity: 5 } }

--- a/RetiledStyles/AppBarDrawerBase.qml
+++ b/RetiledStyles/AppBarDrawerBase.qml
@@ -85,6 +85,9 @@ T.Drawer {
     leftPadding: control.edge === Qt.RightEdge
     rightPadding: control.edge === Qt.LeftEdge
     bottomPadding: control.edge === Qt.TopEdge
+	
+	// Don't have it drag on the edge, because we're overriding this.
+	dragMargin: 0
 
     enter: Transition { SmoothedAnimation { velocity: 5 } }
     exit: Transition { SmoothedAnimation { velocity: 5 } }

--- a/RetiledStyles/AppBarDrawerBase.qml
+++ b/RetiledStyles/AppBarDrawerBase.qml
@@ -93,7 +93,7 @@ T.Drawer {
         Rectangle {
             readonly property bool horizontal: control.edge === Qt.LeftEdge || control.edge === Qt.RightEdge
             width: horizontal ? 1 : parent.width
-            height: horizontal ? parent.height : 1
+            height: 0
             color: control.Universal.chromeHighColor
             x: control.edge === Qt.LeftEdge ? parent.width - 1 : 0
             y: control.edge === Qt.TopEdge ? parent.height - 1 : 0

--- a/RetiledStyles/AppBarDrawerBase.qml
+++ b/RetiledStyles/AppBarDrawerBase.qml
@@ -103,6 +103,10 @@ T.Drawer {
             y: control.edge === Qt.TopEdge ? parent.height - 1 : 0
         }
     }
+	
+	// Not sure where to put this, but I'm trying to get the drawer to tap-open or drag-open
+	// only on the more button and at the far left side. This may help somewhat:
+	// https://stackoverflow.com/a/49494819
 
     T.Overlay.modal: Rectangle {
         color: "transparent"

--- a/RetiledStyles/AppBarDrawerBase.qml
+++ b/RetiledStyles/AppBarDrawerBase.qml
@@ -2,3 +2,109 @@
 // the Overlay.modal rectangle color set to transparent.
 // Anything else specific to the appbar drawer will be set in
 // AppBarDrawer.qml.
+
+/****************************************************************************
+**
+** Copyright (C) 2017 The Qt Company Ltd.
+** Contact: http://www.qt.io/licensing/
+**
+** This file is part of the Qt Quick Controls 2 module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL3$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see http://www.qt.io/terms-conditions. For further
+** information use the contact form at http://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or later as published by the Free
+** Software Foundation and appearing in the file LICENSE.GPL included in
+** the packaging of this file. Please review the following information to
+** ensure the GNU General Public License version 2.0 requirements will be
+** met: http://www.gnu.org/licenses/gpl-2.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+// RetiledStyles - Windows Phone 8.x-like QML styles for the
+//                 Retiled project. Some code was copied from
+//                 the official qtdeclarative repo, which you can
+//                 access a copy of here:
+//                 https://github.com/DrewNaylor/qtdeclarative
+// Modifications to this file are Copyright (C) 2021 Drew Naylor
+// Please refer to The Qt Company's copyrights above
+// for the copyrights to the original file.
+// (Note that the copyright years include the years left out by the hyphen.)
+// Windows Phone and all other related copyrights and trademarks are property
+// of Microsoft Corporation. All rights reserved.
+//
+// This file was modified from the original QtQuick Controls source.
+// In particular, I took code from the Universal style's "Button.qml" file.
+// You can get a copy of the source from here:
+// https://github.com/DrewNaylor/qtdeclarative
+//
+// This file is a part of the RetiledStyles project, which is used by Retiled.
+// Neither Retiled nor Drew Naylor are associated with Microsoft
+// and Microsoft does not endorse Retiled.
+// Any other copyrights and trademarks belong to their
+// respective people and companies/organizations.
+//
+//
+//   Please refer to the licensing info above for the licenses this file falls
+//   under.
+
+import QtQuick
+import QtQuick.Templates as T
+import QtQuick.Controls.Universal
+
+T.Drawer {
+    id: control
+
+    parent: T.Overlay.overlay
+
+    implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset,
+                            contentWidth + leftPadding + rightPadding)
+    implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
+                             contentHeight + topPadding + bottomPadding)
+
+    topPadding: control.edge === Qt.BottomEdge
+    leftPadding: control.edge === Qt.RightEdge
+    rightPadding: control.edge === Qt.LeftEdge
+    bottomPadding: control.edge === Qt.TopEdge
+
+    enter: Transition { SmoothedAnimation { velocity: 5 } }
+    exit: Transition { SmoothedAnimation { velocity: 5 } }
+
+    background: Rectangle {
+        color: control.Universal.chromeMediumLowColor
+        Rectangle {
+            readonly property bool horizontal: control.edge === Qt.LeftEdge || control.edge === Qt.RightEdge
+            width: horizontal ? 1 : parent.width
+            height: horizontal ? parent.height : 1
+            color: control.Universal.chromeHighColor
+            x: control.edge === Qt.LeftEdge ? parent.width - 1 : 0
+            y: control.edge === Qt.TopEdge ? parent.height - 1 : 0
+        }
+    }
+
+    T.Overlay.modal: Rectangle {
+        color: control.Universal.baseLowColor
+    }
+
+    T.Overlay.modeless: Rectangle {
+        color: control.Universal.baseLowColor
+    }
+}

--- a/RetiledStyles/AppBarDrawerBase.qml
+++ b/RetiledStyles/AppBarDrawerBase.qml
@@ -45,6 +45,7 @@
 //                 access a copy of here:
 //                 https://github.com/DrewNaylor/qtdeclarative
 // Modifications to this file are Copyright (C) 2021 Drew Naylor
+// and are licensed under the LGPLv3.
 // Please refer to The Qt Company's copyrights above
 // for the copyrights to the original file.
 // (Note that the copyright years include the years left out by the hyphen.)

--- a/RetiledStyles/AppBarDrawerEntry.qml
+++ b/RetiledStyles/AppBarDrawerEntry.qml
@@ -1,0 +1,115 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 The Qt Company Ltd.
+** Contact: http://www.qt.io/licensing/
+**
+** This file is part of the Qt Quick Controls 2 module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL3$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see http://www.qt.io/terms-conditions. For further
+** information use the contact form at http://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPLv3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or later as published by the Free
+** Software Foundation and appearing in the file LICENSE.GPL included in
+** the packaging of this file. Please review the following information to
+** ensure the GNU General Public License version 2.0 requirements will be
+** met: http://www.gnu.org/licenses/gpl-2.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+// RetiledStyles - Windows Phone 8.x-like QML styles for the
+//                 Retiled project. Some code was copied from
+//                 the official qtdeclarative repo, which you can
+//                 access a copy of here:
+//                 https://github.com/DrewNaylor/qtdeclarative
+// Modifications to this file are Copyright (C) 2021 Drew Naylor
+// and are licensed under the LGPLv3.
+// Please refer to The Qt Company's copyrights above
+// for the copyrights to the original file.
+// (Note that the copyright years include the years left out by the hyphen.)
+// Windows Phone and all other related copyrights and trademarks are property
+// of Microsoft Corporation. All rights reserved.
+//
+// This file was modified from the original QtQuick Controls source.
+// In particular, I took code from the Universal style's "Button.qml" file.
+// You can get a copy of the source from here:
+// https://github.com/DrewNaylor/qtdeclarative
+//
+// This file is a part of the RetiledStyles project, which is used by Retiled.
+// Neither Retiled nor Drew Naylor are associated with Microsoft
+// and Microsoft does not endorse Retiled.
+// Any other copyrights and trademarks belong to their
+// respective people and companies/organizations.
+//
+//
+//   Please refer to the licensing info above for the licenses this file falls
+//   under.
+
+
+import QtQuick
+import QtQuick.Templates as T
+import QtQuick.Controls.impl
+import QtQuick.Controls.Universal
+
+T.ItemDelegate {
+    id: control
+
+    implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset,
+                            implicitContentWidth + leftPadding + rightPadding)
+    implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
+                             implicitContentHeight + topPadding + bottomPadding,
+                             implicitIndicatorHeight + topPadding + bottomPadding)
+
+    spacing: 12
+
+    padding: 12
+    topPadding: padding - 1
+    bottomPadding: padding + 1
+
+    icon.width: 20
+    icon.height: 20
+    icon.color: Color.transparent(Universal.foreground, enabled ? 1.0 : 0.2)
+
+    contentItem: IconLabel {
+        spacing: control.spacing
+        mirrored: control.mirrored
+        display: control.display
+        alignment: control.display === IconLabel.IconOnly || control.display === IconLabel.TextUnderIcon ? Qt.AlignCenter : Qt.AlignLeft
+
+        icon: control.icon
+        text: control.text
+        font: control.font
+        color: Color.transparent(control.Universal.foreground, enabled ? 1.0 : 0.2)
+    }
+
+    background: Rectangle {
+        visible: control.down || control.highlighted || control.visualFocus || control.hovered
+        color: control.down ? control.Universal.listMediumColor :
+               control.hovered ? control.Universal.listLowColor : control.Universal.altMediumLowColor
+        Rectangle {
+            width: parent.width
+            height: parent.height
+            visible: control.visualFocus || control.highlighted
+            color: control.Universal.accent
+            opacity: control.Universal.theme === Universal.Light ? 0.4 : 0.6
+        }
+
+    }
+}

--- a/RetiledStyles/AppBarDrawerEntry.qml
+++ b/RetiledStyles/AppBarDrawerEntry.qml
@@ -98,7 +98,8 @@ T.ItemDelegate {
 
         icon: control.icon
         text: control.text
-        font: control.font
+        font.family: "Open Sans"
+		font.pointSize: 14
         color: Color.transparent(control.Universal.foreground, enabled ? 1.0 : 0.2)
     }
 

--- a/RetiledStyles/AppBarDrawerEntry.qml
+++ b/RetiledStyles/AppBarDrawerEntry.qml
@@ -100,6 +100,8 @@ T.ItemDelegate {
         text: control.text
         font.family: "Open Sans"
 		font.pointSize: 14
+		font.weight: Font.Normal
+		font.letterSpacing: -0.8 * scaleFactor
         color: Color.transparent(control.Universal.foreground, enabled ? 1.0 : 0.2)
     }
 

--- a/RetiledStyles/AppBarDrawerEntry.qml
+++ b/RetiledStyles/AppBarDrawerEntry.qml
@@ -98,6 +98,7 @@ T.ItemDelegate {
 
         icon: control.icon
         text: control.text
+		// Change font to Open Sans and do the other stuff.
         font.family: "Open Sans"
 		font.pointSize: 14
 		font.weight: Font.Normal

--- a/RetiledStyles/AppBarDrawerEntry.qml
+++ b/RetiledStyles/AppBarDrawerEntry.qml
@@ -82,6 +82,9 @@ T.ItemDelegate {
     padding: 12
     topPadding: padding - 1
     bottomPadding: padding + 1
+	
+	// Scale it down like a button.
+	scale: down ? 0.98 : 1.0
 
     icon.width: 20
     icon.height: 20
@@ -101,8 +104,7 @@ T.ItemDelegate {
 
     background: Rectangle {
         visible: control.down || control.highlighted || control.visualFocus || control.hovered
-        color: control.down ? control.Universal.listMediumColor :
-               control.hovered ? control.Universal.listLowColor : control.Universal.altMediumLowColor
+        color: "transparent"
         Rectangle {
             width: parent.width
             height: parent.height

--- a/RetiledStyles/AppBarMoreButton.qml
+++ b/RetiledStyles/AppBarMoreButton.qml
@@ -65,29 +65,48 @@
 
 import QtQuick
 import QtQuick.Templates as T
+import QtQuick.Controls.impl
 import QtQuick.Controls.Universal
 
-T.Popup {
+T.ToolButton {
     id: control
 
     implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset,
-                            contentWidth + leftPadding + rightPadding)
+                            implicitContentWidth + leftPadding + rightPadding)
     implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
-                             contentHeight + topPadding + bottomPadding)
+                             implicitContentHeight + topPadding + bottomPadding)
 
-    padding: 0
+    padding: 6
+    spacing: 8
+
+    icon.width: 20
+    icon.height: 20
+    icon.color: Color.transparent(Universal.foreground, enabled ? 1.0 : 0.2)
+
+    property bool useSystemFocusVisuals: true
+
+    contentItem: IconLabel {
+        spacing: control.spacing
+        mirrored: control.mirrored
+        display: control.display
+
+        icon: control.icon
+        text: control.text
+        font: control.font
+        color: Color.transparent(control.Universal.foreground, enabled ? 1.0 : 0.2)
+    }
 
     background: Rectangle {
-        color: "white"
-        border.color: "black"
-        border.width: 2 // FlyoutBorderThemeThickness
-    }
+        implicitWidth: 68
+        implicitHeight: 48 // AppBarThemeCompactHeight
 
-    T.Overlay.modal: Rectangle {
-        color: "transparent"
-    }
+        color: control.enabled && (control.highlighted || control.checked) ? control.Universal.accent : "transparent"
 
-    T.Overlay.modeless: Rectangle {
-        color: "transparent"
+        Rectangle {
+            width: parent.width
+            height: parent.height
+            visible: control.down || control.hovered
+            color: control.down ? control.Universal.listMediumColor : control.Universal.listLowColor
+        }
     }
 }

--- a/RetiledStyles/AppBarMoreButton.qml
+++ b/RetiledStyles/AppBarMoreButton.qml
@@ -106,7 +106,7 @@ T.ToolButton {
             width: parent.width
             height: parent.height
             visible: control.down || control.hovered
-            color: control.down ? control.Universal.listMediumColor : control.Universal.listLowColor
+            color: "transparent"
         }
     }
 }

--- a/RetiledStyles/ButtonBase.qml
+++ b/RetiledStyles/ButtonBase.qml
@@ -40,6 +40,7 @@
 //                 access a copy of here:
 //                 https://github.com/DrewNaylor/qtdeclarative
 // Modifications to this file are Copyright (C) 2021 Drew Naylor
+// and are licensed under the LGPLv3.
 // Please refer to The Qt Company's copyrights above
 // for the copyrights to the original file.
 // (Note that the copyright years include the years left out by the hyphen.)

--- a/RetiledStyles/TextFieldBase.qml
+++ b/RetiledStyles/TextFieldBase.qml
@@ -40,6 +40,7 @@
 //                 access a copy of here:
 //                 https://github.com/DrewNaylor/qtdeclarative
 // Modifications to this file are Copyright (C) 2021 Drew Naylor
+// and are licensed under the LGPLv3.
 // Please refer to The Qt Company's copyrights above
 // for the copyrights to the original file.
 // (Note that the copyright years include the years left out by the hyphen.)


### PR DESCRIPTION
The appbar drawer in the search app looks correct now, and I've also clarified that my modifications to the styles from Qt are also under the LGPLv3. I'd prefer to let them be under the Apache License, version 2.0, or another similar permissive license, but I don't want to mess things up.