### PR TITLE
Display window title text below previews in multitasking + allow scrolling multitasking as a list so it's usable on a phone.

### DIFF
--- a/RetiledCompositor/RetiledCompositor/MainWindow.qml
+++ b/RetiledCompositor/RetiledCompositor/MainWindow.qml
@@ -221,9 +221,6 @@ WaylandCompositor {
                 Repeater {
                     model: toplevels
                     Item {
-						// Column and extra Item thing to allow for displaying window title text added under GPLv3 and Copyright (C) Drew Naylor.
-						Column {
-						Item {
                         width: win.width
                         height: win.height
                         ShellSurfaceItem {
@@ -308,15 +305,7 @@ WaylandCompositor {
                                 grid.overview = false;
                             }
                         }
-						} // Close the new Item block for just the preview.
-						Item {
-							// Display the window title text on a transparent background.
-							Label {
-								text: "test"
-							}
-						}
-						} // Close the column holding the preview item and the label item.
-                    } // Close the Item block containing the stack view to hold both an item for the preview and a window label.
+                    }
                 }
                 // ![toplevels repeater]
             }

--- a/RetiledCompositor/RetiledCompositor/MainWindow.qml
+++ b/RetiledCompositor/RetiledCompositor/MainWindow.qml
@@ -217,8 +217,8 @@ Flickable {
                 // ![zoom transform]
                 transform: [
                     Scale {
-                        xScale: grid.overview ? (1.0/grid.columns) : 1
-                        yScale: grid.overview ? (1.0/grid.columns) : 1
+                        xScale: grid.overview ? 0.5 : 1
+                        yScale: grid.overview ? 0.5 : 1
                         Behavior on xScale { PropertyAnimation { easing.type: Easing.InOutQuad; duration: 200 } }
                         Behavior on yScale { PropertyAnimation { easing.type: Easing.InOutQuad; duration: 200 } }
                     },

--- a/RetiledCompositor/RetiledCompositor/MainWindow.qml
+++ b/RetiledCompositor/RetiledCompositor/MainWindow.qml
@@ -220,6 +220,10 @@ WaylandCompositor {
                 // ![toplevels repeater]
                 Repeater {
                     model: toplevels
+					ColumnLayout {
+                        // ColumnLayout added under GPLv3 and Copyright (C) Drew Naylor
+                        // to allow the title text to be displayed for each preview,
+                        // like on Windows Phone.
                     Item {
                         width: win.width
                         height: win.height
@@ -305,11 +309,13 @@ WaylandCompositor {
                                 grid.overview = false;
                             }
                         }
-						Label {
+                    }
+					Item {
+                        height: 50
+                        Label {
                             // Adding this label to display the current app under GPLv3 and Copyright (C) Drew Naylor.
+							// The idea for this is from Windows Phone. I can't take credit for it.
                             visible: grid.overview
-                            anchors.bottom: parent.bottom
-                            anchors.left: parent.left
                             color: "white"
                             font.pixelSize: 40
                             // Had to look at this video at 18:57 to figure out how to get the title text,
@@ -318,8 +324,9 @@ WaylandCompositor {
                             // get what we needed:
                             // https://www.youtube.com/watch?v=mIg1P3i2ZfI
                             text: xdgSurface.toplevel.title
-                        }
-                    }
+                        } // Close the label at the bottom.
+                    } // Close the new item holder.
+                    } // Close the new ColumnLayout.
                 }
                 // ![toplevels repeater]
             }

--- a/RetiledCompositor/RetiledCompositor/MainWindow.qml
+++ b/RetiledCompositor/RetiledCompositor/MainWindow.qml
@@ -191,6 +191,20 @@ WaylandCompositor {
                 //     closePolicy: Popup.CloseOnEscape
                 // }
 
+Flickable {
+	// Allow the multitasking area to be scrolled up and down
+	// with equal-sized window cards
+	// until a proper left-right swipe is implemented.
+	// Flickable added under GPLv3 and Copyright (C) Drew Naylor.
+    id: multitaskingFlickable
+    anchors.fill: parent
+    interactive: grid.overview
+	// We have to tell it how tall its contents are supposed to be or it'll bounce back up:
+	// https://forum.qt.io/topic/38640/solved-scrollable-grid-in-qt/3
+    contentHeight: toplevels.count * 125
+    contentWidth: grid.width
+    flickableDirection: Flickable.VerticalFlick
+
             Grid {
                 id: grid
 
@@ -334,9 +348,10 @@ WaylandCompositor {
                         } // Close the label at the bottom.
                     } // Close the new item holder.
                     } // Close the new ColumnLayout.
-                }
+                } // Close the repeater.
                 // ![toplevels repeater]
-            }
+                } // Close the grid.
+} // Close the flickable.
 
 			// Rectangle added under GPLv3 and change Copyright (C) Drew Naylor.
 			Rectangle {

--- a/RetiledCompositor/RetiledCompositor/MainWindow.qml
+++ b/RetiledCompositor/RetiledCompositor/MainWindow.qml
@@ -201,6 +201,9 @@ Flickable {
     interactive: grid.overview
 	// We have to tell it how tall its contents are supposed to be or it'll bounce back up:
 	// https://forum.qt.io/topic/38640/solved-scrollable-grid-in-qt/3
+	// This 125 value is a bit too much, but at least it's more than necessary
+	// rather than not enough.
+	// TODO: Figure out how to only show exactly what is needed for the windows in multitasking.
     contentHeight: toplevels.count * 125
     contentWidth: grid.width
     flickableDirection: Flickable.VerticalFlick

--- a/RetiledCompositor/RetiledCompositor/MainWindow.qml
+++ b/RetiledCompositor/RetiledCompositor/MainWindow.qml
@@ -221,6 +221,9 @@ WaylandCompositor {
                 Repeater {
                     model: toplevels
                     Item {
+						// Column and extra Item thing to allow for displaying window title text added under GPLv3 and Copyright (C) Drew Naylor.
+						Column {
+						Item {
                         width: win.width
                         height: win.height
                         ShellSurfaceItem {
@@ -305,7 +308,15 @@ WaylandCompositor {
                                 grid.overview = false;
                             }
                         }
-                    }
+						} // Close the new Item block for just the preview.
+						Item {
+							// Display the window title text on a transparent background.
+							Label {
+								text: "test"
+							}
+						}
+						} // Close the column holding the preview item and the label item.
+                    } // Close the Item block containing the stack view to hold both an item for the preview and a window label.
                 }
                 // ![toplevels repeater]
             }

--- a/RetiledCompositor/RetiledCompositor/MainWindow.qml
+++ b/RetiledCompositor/RetiledCompositor/MainWindow.qml
@@ -210,7 +210,10 @@ WaylandCompositor {
                     },
                     Translate {
                         x: grid.overview ? 0 : win.width * -grid.selectedColumn
-                        y: grid.overview ? 0 : win.height * -grid.selectedRow
+                        // The subtracting 55 multiplied by the selectedRow or 0 based on the selectedRow was added under the GPLv3 and Copyright (C) Drew Naylor.
+                        // It's there to ensurethe title text doesn't interfere with the window when
+                        // bringing it back into focus so it's in the right spot.
+                        y: grid.overview ? 0 : win.height * -grid.selectedRow - (grid.selectedRow > 0 ? 55 * grid.selectedRow : 0)
                         Behavior on x { PropertyAnimation { easing.type: Easing.InOutQuad; duration: 200 } }
                         Behavior on y { PropertyAnimation { easing.type: Easing.InOutQuad; duration: 200 } }
                     }

--- a/RetiledCompositor/RetiledCompositor/MainWindow.qml
+++ b/RetiledCompositor/RetiledCompositor/MainWindow.qml
@@ -224,6 +224,7 @@ Flickable {
                 // ![zoom transform]
                 transform: [
                     Scale {
+                        // xScale and yScale changed to be 0.5 when in multitasking under GPLv3 and Copyright (C) Drew Naylor.
                         xScale: grid.overview ? 0.5 : 1
                         yScale: grid.overview ? 0.5 : 1
                         Behavior on xScale { PropertyAnimation { easing.type: Easing.InOutQuad; duration: 200 } }

--- a/RetiledCompositor/RetiledCompositor/MainWindow.qml
+++ b/RetiledCompositor/RetiledCompositor/MainWindow.qml
@@ -305,6 +305,20 @@ WaylandCompositor {
                                 grid.overview = false;
                             }
                         }
+						Label {
+                            // Adding this label to display the current app under GPLv3 and Copyright (C) Drew Naylor.
+                            visible: grid.overview
+                            anchors.bottom: parent.bottom
+                            anchors.left: parent.left
+                            color: "white"
+                            font.pixelSize: 40
+                            // Had to look at this video at 18:57 to figure out how to get the title text,
+                            // but even then it was different from the video and I just based it off the
+                            // xdgSurface.toplevel.sendClose() call above, because I figured that would
+                            // get what we needed:
+                            // https://www.youtube.com/watch?v=mIg1P3i2ZfI
+                            text: xdgSurface.toplevel.title
+                        }
                     }
                 }
                 // ![toplevels repeater]

--- a/RetiledCompositor/RetiledCompositor/MainWindow.qml
+++ b/RetiledCompositor/RetiledCompositor/MainWindow.qml
@@ -309,6 +309,10 @@ WaylandCompositor {
                             anchors.fill: parent
                             onClicked: {
                                 grid.selected = index;
+								// Ensure the multitasking flickable has its contentY
+                                // set to the y-value of the MouseArea.
+                                // Doing the y-value thing under the GPLv3 and is Copyright (C) Drew Naylor.
+                                multitaskingFlickable.contentY = parent.y
                                 grid.overview = false;
                             }
                         }


### PR DESCRIPTION
See also #162. The vertical scrolling list for multitasking is temporary as this is just to make it usable on a phone. Later it'll be changed to be pages that can be swiped between like in Windows Phone. The text under the preview may need to be adjusted eventually.

I think this still has a bit of a problem as the grid might not be forcing it to two columns, resulting in window previews just showing up from the fourth dimension when closing some. Fine for now, though.

I should write about how this works, but I tried to make sure it's described in the code at least. Basically, I had to have the Flickable keep the current y-value when zooming out to know what to go back to when leaving multitasking with a shortcut or the Back button, and tapping a preview updates the y-value. This does need to be changed to get the newest-added y-value, though, until a better way is implemented not using the grid. It currently goes all the way back to the top when going into multitasking, for example.

Edit: Currently it has some major issues, like not recalculating the Flickable's contentHeight when closing windows like it's supposed to resulting in not being able to see everything if you've closed and opened a decent amount of stuff in a session. The code that figures out how big the contentHeight should be also seems to give way too much height sometimes so you get a bunch of empty space, but it's not much of an issue right now. I'll probably merge even with this issue because it's early in development, but this will be a note.