### PR TITLE
Parallax tile wallpapers (initial implementation)

### DIFF
--- a/RetiledStart/RetiledStart/pages/Tiles.qml
+++ b/RetiledStart/RetiledStart/pages/Tiles.qml
@@ -336,33 +336,35 @@ ApplicationWindow {
 				//// so it doesn't show the edge of the image.
 				//y: tilesContainer.height * -0.1
 				
-					//Image {
-						//id: tileWallpaper
-						//fillMode: Image.PreserveAspectCrop
-						//// Setting the width to tilesContainer's width plus 50
-						//// ensures empty space on the right is hidden.
-						//width: tilesContainer.width + 50
-						//// Setting the height to the window's height multiplied
-						//// by 1.2 ensures the image is at least as tall as the
-						//// window, but this introduces a problem if there are enough
-						//// tiles to make the tilesContainer taller than the window.
-						//// The solution to this doesn't seem to be to use the tilesContainer's
-						//// height, because resizing, pinning, and unpinning tiles
-						//// will change the height of the tilesContainer, and thus the
-						//// background image.
-						//height: window.height * 1.2
-						//// Ensure the image doesn't go into the All Apps list area.
-						//// This may be desirable for some if they want it like
-						//// Windows 10 Mobile, but there's no horizontal parallax for the image
-						//// yet, so it just ends up showing part of itself in the All Apps area.
-						//// As stated at the bottom of this section, it's important to clip an image if
-						//// using PreserveAspectCrop, as it can still go outside its intended bounds:
-						//// https://doc.qt.io/qt-6/qml-qtquick-image.html#fillMode-prop
-						//clip: true
-						//source: "wallpaper.jpg"
-						//visible: true
+					Image {
+						id: tileWallpaper
+						fillMode: Image.PreserveAspectCrop
+						// Setting the width to tilesContainer's width plus 50
+						// ensures empty space on the right is hidden.
+						width: tilesContainer.width + 50
+						// Setting the height to the window's height multiplied
+						// by 1.2 ensures the image is at least as tall as the
+						// window, but this introduces a problem if there are enough
+						// tiles to make the tilesContainer taller than the window.
+						// The solution to this doesn't seem to be to use the tilesContainer's
+						// height, because resizing, pinning, and unpinning tiles
+						// will change the height of the tilesContainer, and thus the
+						// background image.
+						height: window.height * 1.2
+						// Ensure the image doesn't go into the All Apps list area.
+						// This may be desirable for some if they want it like
+						// Windows 10 Mobile, but there's no horizontal parallax for the image
+						// yet, so it just ends up showing part of itself in the All Apps area.
+						// As stated at the bottom of this section, it's important to clip an image if
+						// using PreserveAspectCrop, as it can still go outside its intended bounds:
+						// https://doc.qt.io/qt-6/qml-qtquick-image.html#fillMode-prop
+						clip: true
+						source: "wallpaper.jpg"
+						visible: true
+						
+						y: -tilesFlickable.contentY * 0.12
 					
-					//} //// End of the tile area background image item.
+					} //// End of the tile area background image item.
 		//} //// End of the flickable allowing the background image to have some parallax scrolling.
 		
 	Flickable {

--- a/RetiledStart/RetiledStart/pages/Tiles.qml
+++ b/RetiledStart/RetiledStart/pages/Tiles.qml
@@ -404,7 +404,7 @@ ApplicationWindow {
 		Item {
 			// Create an empty item so the area above
 			// the tiles works as a scrollable area.
-			id: tilesPageTopMargin
+			id: tilesPageTopSpacer
 			height: 37
 			
 		}

--- a/RetiledStart/RetiledStart/pages/Tiles.qml
+++ b/RetiledStart/RetiledStart/pages/Tiles.qml
@@ -404,6 +404,7 @@ ApplicationWindow {
 		Item {
 			// Create an empty item so the area above
 			// the tiles works as a scrollable area.
+			id: tilesPageTopMargin
 			height: 37
 			
 		}

--- a/RetiledStart/RetiledStart/pages/Tiles.qml
+++ b/RetiledStart/RetiledStart/pages/Tiles.qml
@@ -55,11 +55,16 @@ ApplicationWindow {
 	Universal.background: 'black'
 	
 	// Decide whether to display a background image or not.
-	// This is also used to determine if we should use
+	// This (displayBackgroundWallpaper) is used in conjunction with
+	// useTileBackgroundWallpaper to determine if we should use
 	// a tile background (in-tile, like 8.1),
-	// but will be displayed behind the tiles like 10
-	// if the in-tile background is turned off.
-	property bool displayBackgroundWallpaper: false
+	// or if it should be displayed behind the tiles like 10
+	// if useTileBackgroundWallpaper is false.
+	// Having both be false will just do the solid-color tiles
+	// like 7.x-8.0.
+	// TODO: Make it easy to configure the image to use
+	// without having to switch the file or manually edit the code.
+	property bool displayBackgroundWallpaper: true
 	property bool useTileBackgroundWallpaper: false
 	
 	// Global edit mode property so we can check to see if

--- a/RetiledStart/RetiledStart/pages/Tiles.qml
+++ b/RetiledStart/RetiledStart/pages/Tiles.qml
@@ -54,6 +54,13 @@ ApplicationWindow {
 	// This will probably be useful when working on stuff like the volume controls and Action Center.
 	Universal.background: 'black'
 	
+	// Decide whether to display a background image or not.
+	// This is also used to determine if we should use
+	// a tile background (in-tile, like 8.1),
+	// but will be displayed behind the tiles like 10
+	// if the in-tile background is turned off.
+	property bool displayBackgroundWallpaper: true
+	
 	// Global edit mode property so we can check to see if
 	// edit mode is turned on globally when tapping a tile.
 	// If it is, we'll turn local edit mode on for that tile
@@ -360,7 +367,7 @@ ApplicationWindow {
 						// https://doc.qt.io/qt-6/qml-qtquick-image.html#fillMode-prop
 						clip: true
 						source: "wallpaper.jpg"
-						visible: true
+						visible: displayBackgroundWallpaper
 						
 						y: -tilesFlickable.contentY * 0.12
 					
@@ -450,29 +457,32 @@ ApplicationWindow {
 				//onPressAndHold: console.log("We can definitely do this!")
 				//onClicked: console.log("The future doesn't belong to you!")
 				//}
-				//RetiledStyles.Tile {
-				//tileText: qsTr("WP8.1 app with a really long name")
-				//width: 150
-				//height: 150
-				//// You can access code in the main.py file from QML sub-pages.
-				//onClicked: allAppsListViewModel.getDotDesktopFiles()
-				//}
-				//RetiledStyles.Tile {
-				//tileText: qsTr("WP8.1 app with a really long name")
-				//width: 310
-				//height: 150
-				//onClicked: tilesListViewModel.getTilesList()
-				//}
-				//RetiledStyles.Tile {
-				//tileText: qsTr("WP8.1 app with a really long name")
-				//width: 150
-				//height: 150
-				//}
-				//RetiledStyles.Tile {
-				//tileText: qsTr("WP8.1 app with a really long name")
-				//width: 70
-				//height: 70
-				//}
+				/* RetiledStyles.Tile {
+				tileText: qsTr("WP8.1 app with a really long name")
+				width: 150
+				height: 150
+				tileBackgroundColor: "red"
+				// You can access code in the main.py file from QML sub-pages.
+				onClicked: allAppsListViewModel.getDotDesktopFiles()
+				}
+				RetiledStyles.Tile {
+				tileText: qsTr("WP8.1 app with a really long name")
+				width: 310
+				height: 150
+				tileBackgroundColor: "purple"
+				onClicked: tilesListViewModel.getTilesList()
+				}
+				RetiledStyles.Tile {
+				tileText: qsTr("WP8.1 app with a really long name")
+				width: 150
+				height: 150
+				tileBackgroundColor: "orange"
+				}
+				RetiledStyles.Tile {
+				tileText: qsTr("WP8.1 app with a really long name")
+				width: 70
+				height: 70
+				} */
 				
 				// Set up the tile click signals.
 				function tileClicked(execKey) {
@@ -495,6 +505,7 @@ ApplicationWindow {
 							NewTileObject.tileText = allAppsListViewModel.GetDesktopEntryNameKey(dotDesktopFilePath);
 							NewTileObject.width = 150;
 							NewTileObject.height = 150;
+							NewTileObject.useTileBackgroundWallpaper = displayBackgroundWallpaper;
 							// TODO: Add another property to tiles so they'll default to
 							// using accent colors unless the boolean to use accent colors
 							// is off, in which case they'll use a specified tile background
@@ -687,6 +698,7 @@ ApplicationWindow {
 							NewTileObject.width = ParsedTilesList[i].TileWidth;
 							NewTileObject.height = ParsedTilesList[i].TileHeight;
 							NewTileObject.tileBackgroundColor = accentColor;
+							NewTileObject.useTileBackgroundWallpaper = displayBackgroundWallpaper;
 						// Doesn't quite work on Windows because the hardcoded tile is trying to read
 						// from /usr/share/applications and can't find Firefox.
 						// Turns out it was trying to run Firefox. Not sure how to stop that.

--- a/RetiledStart/RetiledStart/pages/Tiles.qml
+++ b/RetiledStart/RetiledStart/pages/Tiles.qml
@@ -64,7 +64,7 @@ ApplicationWindow {
 	// like 7.x-8.0.
 	// TODO: Make it easy to configure the image to use
 	// without having to switch the file or manually edit the code.
-	property bool displayBackgroundWallpaper: true
+	property bool displayBackgroundWallpaper: false
 	property bool useTileBackgroundWallpaper: false
 	
 	// Global edit mode property so we can check to see if

--- a/RetiledStart/RetiledStart/pages/Tiles.qml
+++ b/RetiledStart/RetiledStart/pages/Tiles.qml
@@ -59,7 +59,8 @@ ApplicationWindow {
 	// a tile background (in-tile, like 8.1),
 	// but will be displayed behind the tiles like 10
 	// if the in-tile background is turned off.
-	property bool displayBackgroundWallpaper: true
+	property bool displayBackgroundWallpaper: false
+	property bool useTileBackgroundWallpaper: false
 	
 	// Global edit mode property so we can check to see if
 	// edit mode is turned on globally when tapping a tile.
@@ -505,7 +506,9 @@ ApplicationWindow {
 							NewTileObject.tileText = allAppsListViewModel.GetDesktopEntryNameKey(dotDesktopFilePath);
 							NewTileObject.width = 150;
 							NewTileObject.height = 150;
-							NewTileObject.useTileBackgroundWallpaper = displayBackgroundWallpaper;
+							// Set the boolean to use the tile background wallpaper on this tile,
+							// according to the user's choices in the config file.
+							NewTileObject.useTileBackgroundWallpaper = useTileBackgroundWallpaper;
 							// TODO: Add another property to tiles so they'll default to
 							// using accent colors unless the boolean to use accent colors
 							// is off, in which case they'll use a specified tile background
@@ -698,7 +701,9 @@ ApplicationWindow {
 							NewTileObject.width = ParsedTilesList[i].TileWidth;
 							NewTileObject.height = ParsedTilesList[i].TileHeight;
 							NewTileObject.tileBackgroundColor = accentColor;
-							NewTileObject.useTileBackgroundWallpaper = displayBackgroundWallpaper;
+							// Set the boolean to use the tile background wallpaper on this tile,
+							// according to the user's choices in the config file.
+							NewTileObject.useTileBackgroundWallpaper = useTileBackgroundWallpaper;
 						// Doesn't quite work on Windows because the hardcoded tile is trying to read
 						// from /usr/share/applications and can't find Firefox.
 						// Turns out it was trying to run Firefox. Not sure how to stop that.

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -601,7 +601,7 @@ ButtonBase {
 		// https://doc.qt.io/qt-6/qml-qtquick-shadereffectsource.html
 		
 		sourceItem: tileWallpaper
-		sourceRect: Qt.rect(parent.x, tileWallpaper.y + (-tilesFlickable.contentY + tilesFlickable.height / window.height) + parent.y, parent.width, parent.height)
+		sourceRect: Qt.rect(parent.x, (-tilesFlickable.contentY + tilesFlickable.height / window.height) + parent.y - tileWallpaper.y, parent.width, parent.height)
 		live: true
 		hideSource: true
 		

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -601,7 +601,7 @@ ButtonBase {
 		// https://doc.qt.io/qt-6/qml-qtquick-shadereffectsource.html
 		
 		sourceItem: tileWallpaper
-		sourceRect: Qt.rect(parent.x, tileWallpaper.y + parent.y, parent.width, parent.height)
+		sourceRect: Qt.rect(parent.x, (tileWallpaper.y + (-tilesFlickable.contentY * 0.12) + parent.y), parent.width, parent.height)
 		live: true
 		hideSource: true
 		

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -119,6 +119,16 @@ ButtonBase {
 	// This is a property so it can be set
 	// by a setting in the future.
 	property bool tilt: true
+	
+	// Specify whether we should be using
+	// a tile background wallpaper.
+	// If not, we just use the standard Accent
+	// color background.
+	// This can be set per-tile, so there can
+	// also be tiles that just opt out, whether
+	// by the user or by a developer, as well as
+	// if the user says not to use a tile wallpaper.
+	property bool useTileBackgroundWallpaper: false
 					
 	RoundButton {
 		id: unpinButton
@@ -597,7 +607,15 @@ ButtonBase {
 	
 	
 	background: Loader {
-		source: tileBackgroundColor == "#0050ef" ? "./TileBackgroundShaderEffectSource.qml" : "./TileBackgroundSolidColorRectangle.qml"
+		// Ensure we only give tiles that are the same as the Accent color
+		// the tile background wallpaper.
+		// We also check to ensure the user actually wants to use
+		// a tile background wallpaper.
+		// TODO: Remember that we need to allow just using a plain
+		// background wallpaper for devices that can't
+		// handle the in-tile image as well as anyone that just doesn't
+		// want it.
+		source: tileBackgroundColor == accentColor && useTileBackgroundWallpaper == true ? "./TileBackgroundShaderEffectSource.qml" : "./TileBackgroundSolidColorRectangle.qml"
 	}
 	
 	//background: 

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -568,8 +568,8 @@ ButtonBase {
 		// out. But now I'm just doing a hack to force the icon's
 		// source width to be based off it's height, so it's
 		// not as bad as it could be.
-		source: "../icons/actions/unpin_white"
-		//source: getAppIcon.getIcon(dotDesktopFilePath)
+		//source: "../icons/actions/unpin_white"
+		source: getAppIcon.getIcon(dotDesktopFilePath)
 		anchors.fill: parent
 		// Just pad out the image; got the Image.Pad
 		// thing from the QtQuick Image link below.

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -601,7 +601,7 @@ ButtonBase {
 		// https://doc.qt.io/qt-6/qml-qtquick-shadereffectsource.html
 		
 		sourceItem: tileWallpaper
-		sourceRect: Qt.rect(parent.x, (-tilesFlickable.contentY + tilesFlickable.height / window.height) + parent.y - tileWallpaper.y, parent.width, parent.height)
+		sourceRect: Qt.rect(parent.x, tilesPageTopMargin.height + (-tilesFlickable.contentY + tilesFlickable.height / window.height) + parent.y - tileWallpaper.y, parent.width, parent.height)
 		live: true
 		hideSource: true
 		

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -628,6 +628,7 @@ ButtonBase {
 		// the image isn't the right aspect ratio to fill it in; maybe we can
 		// use a different fillMode or make it go slower if the window is smaller/larger?)
 		sourceRect: Qt.rect(parent.x, tilesPageTopSpacer.height + (-tilesFlickable.contentY + tilesFlickable.height / window.height) + parent.y - tileWallpaper.y, parent.width, parent.height)
+		// Hide the image source.
 		hideSource: true
 		
 	}

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -601,10 +601,13 @@ ButtonBase {
 		// https://doc.qt.io/qt-6/qml-qtquick-shadereffectsource.html
 		
 		// Use the tile wallpaper for the source to put as the tile background.
+		// I tried multiplying the width and height by the parent's scale (the tile's scale, that is),
+		// and it's a little weird. There needs to be a way to have the background ignore
+		// changes to scale and tilt, but I'm not sure what to do.
 		// TODO: Figure out how to have it so that pressing a tile doesn't change
 		// the "scale" of the part of the wallpaper shown on a tile
 		// and instead "zooms in" and crops the visible part of the shader
-		// effect source.
+		// effect source. Also do this for the tilt.
 		sourceItem: tileWallpaper
 		// Cut out parts of the wallpaper for each tile.
 		// Here we're taking the current tile's X-value for the

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -601,8 +601,8 @@ ButtonBase {
 		// https://doc.qt.io/qt-6/qml-qtquick-shadereffectsource.html
 		
 		sourceItem: tileWallpaper
-		sourceRect: Qt.rect(parent.x, parent.y, parent.width, parent.height)
-		recursive: true
+		sourceRect: Qt.rect(parent.x, tileWallpaper.y + parent.y, parent.width, parent.height)
+		live: true
 		hideSource: true
 		
 	}

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -594,56 +594,12 @@ ButtonBase {
 		width: parent.width/1.6
 	}
 	
-	background: ShaderEffectSource {
-		
-		// Trying to use ShaderEffectSource to show tile backgrounds.
-		// Docs on ShaderEffectSource:
-		// https://doc.qt.io/qt-6/qml-qtquick-shadereffectsource.html
-		
-		// Use the tile wallpaper for the source to put as the tile background.
-		// I tried multiplying the width and height by the parent's scale (the tile's scale, that is),
-		// and it's a little weird. There needs to be a way to have the background ignore
-		// changes to scale and tilt, but I'm not sure what to do.
-		// TODO: Figure out how to have it so that pressing a tile doesn't change
-		// the "scale" of the part of the wallpaper shown on a tile
-		// and instead "zooms in" and crops the visible part of the shader
-		// effect source. Also do this for the tilt.
-		sourceItem: tileWallpaper
-		// Cut out parts of the wallpaper for each tile.
-		// Here we're taking the current tile's X-value for the
-		// shader effect source's X-value, then (this is complicated)
-		// we add the top spacer above the tiles so that the image
-		// at least shows behind all the tiles at the top, then we take
-		// that and add it to the result of the height of the tilesFlickable (what you
-		// interact with when scrolling through the tiles) divided by the window's height
-		// added to the inverse/negative of the tilesFlickable's current contentY-value,
-		// then we add all that to the tile's Y-value, and finally subtract the tile wallpaper's
-		// current Y-value from it.
-		// The last two are simple: just the tile's width and height.
-		// This will result in the tile wallpaper (assigned as tileWallpaper.source, usually
-		// in "Tiles.qml", but you can use your own Image source if you're using this in
-		// your own app) scrolling "through" the tiles as if they were a window, like
-		// in Windows Phone 8.1.
-		// (This doesn't quite work if the window is too short/wide/skinny/tall and
-		// the image isn't the right aspect ratio to fill it in; maybe we can
-		// use a different fillMode or make it go slower if the window is smaller/larger?)
-		sourceRect: Qt.rect(parent.x, tilesPageTopSpacer.height + (-tilesFlickable.contentY + tilesFlickable.height / window.height) + parent.y - tileWallpaper.y, parent.width, parent.height)
-		// Hide the image source.
-		hideSource: true
-		
+	
+	
+	background: Loader {
+		source: tileBackgroundColor == "#0050ef" ? "./TileBackgroundShaderEffectSource.qml" : "./TileBackgroundSolidColorRectangle.qml"
 	}
 	
-	//background: Rectangle {
-	//	// Change tile color and stuff.
-	//	color: tileBackgroundColor
-	//	border.width: 0
-	//	radius: 0
-		
-	//	// Add antialiasing to tiles.
-	//	// TODO: Allow buttons to have antialiasing turned
-	//	// off, if desired by the user in the settings.
-	//	antialiasing: true
-
-	//}
+	//background: 
 	
 }

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -600,9 +600,31 @@ ButtonBase {
 		// Docs on ShaderEffectSource:
 		// https://doc.qt.io/qt-6/qml-qtquick-shadereffectsource.html
 		
+		// Use the tile wallpaper for the source to put as the tile background.
+		// TODO: Figure out how to have it so that pressing a tile doesn't change
+		// the "scale" of the part of the wallpaper shown on a tile
+		// and instead "zooms in" and crops the visible part of the shader
+		// effect source.
 		sourceItem: tileWallpaper
-		sourceRect: Qt.rect(parent.x, tilesPageTopMargin.height + (-tilesFlickable.contentY + tilesFlickable.height / window.height) + parent.y - tileWallpaper.y, parent.width, parent.height)
-		live: true
+		// Cut out parts of the wallpaper for each tile.
+		// Here we're taking the current tile's X-value for the
+		// shader effect source's X-value, then (this is complicated)
+		// we add the top spacer above the tiles so that the image
+		// at least shows behind all the tiles at the top, then we take
+		// that and add it to the result of the height of the tilesFlickable (what you
+		// interact with when scrolling through the tiles) divided by the window's height
+		// added to the inverse/negative of the tilesFlickable's current contentY-value,
+		// then we add all that to the tile's Y-value, and finally subtract the tile wallpaper's
+		// current Y-value from it.
+		// The last two are simple: just the tile's width and height.
+		// This will result in the tile wallpaper (assigned as tileWallpaper.source, usually
+		// in "Tiles.qml", but you can use your own Image source if you're using this in
+		// your own app) scrolling "through" the tiles as if they were a window, like
+		// in Windows Phone 8.1.
+		// (This doesn't quite work if the window is too short/wide/skinny/tall and
+		// the image isn't the right aspect ratio to fill it in; maybe we can
+		// use a different fillMode or make it go slower if the window is smaller/larger?)
+		sourceRect: Qt.rect(parent.x, tilesPageTopSpacer.height + (-tilesFlickable.contentY + tilesFlickable.height / window.height) + parent.y - tileWallpaper.y, parent.width, parent.height)
 		hideSource: true
 		
 	}

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -601,7 +601,7 @@ ButtonBase {
 		// https://doc.qt.io/qt-6/qml-qtquick-shadereffectsource.html
 		
 		sourceItem: tileWallpaper
-		sourceRect: Qt.rect(parent.x, (tileWallpaper.y + (-tilesFlickable.contentY * 0.12) + parent.y), parent.width, parent.height)
+		sourceRect: Qt.rect(parent.x, tileWallpaper.y + (-tilesFlickable.contentY + tilesFlickable.height / window.height) + parent.y, parent.width, parent.height)
 		live: true
 		hideSource: true
 		

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -128,7 +128,7 @@ ButtonBase {
 	// also be tiles that just opt out, whether
 	// by the user or by a developer, as well as
 	// if the user says not to use a tile wallpaper.
-	property bool useTileBackgroundWallpaper: false
+	property bool useTileBackgroundWallpaper;
 					
 	RoundButton {
 		id: unpinButton
@@ -615,7 +615,7 @@ ButtonBase {
 		// background wallpaper for devices that can't
 		// handle the in-tile image as well as anyone that just doesn't
 		// want it.
-		source: tileBackgroundColor == accentColor && useTileBackgroundWallpaper == true ? "./TileBackgroundShaderEffectSource.qml" : "./TileBackgroundSolidColorRectangle.qml"
+		source: tileBackgroundColor == accentColor && useTileBackgroundWallpaper == true && displayBackgroundWallpaper == true ? "./TileBackgroundShaderEffectSource.qml" : "./TileBackgroundSolidColorRectangle.qml"
 	}
 	
 	//background: 

--- a/RetiledStyles/Tile.qml
+++ b/RetiledStyles/Tile.qml
@@ -545,19 +545,8 @@ ButtonBase {
 				// I wasn't going to do it, but then I went back
 				// and I really don't like how Open Sans looks by default.
             }
-	
-	background: Rectangle {
-		// Change tile color and stuff.
-		color: tileBackgroundColor
-		border.width: 0
-		radius: 0
-		
-		// Add antialiasing to tiles.
-		// TODO: Allow buttons to have antialiasing turned
-		// off, if desired by the user in the settings.
-		antialiasing: true
-
-		Image {
+			
+			Image {
 		// Temporarily grabbing icons directly from the hicolor
 		// theme based on this AskUbuntu answer, notably the "appending
 		// a name to a hardcoded path" thing:
@@ -569,7 +558,8 @@ ButtonBase {
 		// out. But now I'm just doing a hack to force the icon's
 		// source width to be based off it's height, so it's
 		// not as bad as it could be.
-		source: getAppIcon.getIcon(dotDesktopFilePath)
+		source: "../icons/actions/unpin_white"
+		//source: getAppIcon.getIcon(dotDesktopFilePath)
 		anchors.fill: parent
 		// Just pad out the image; got the Image.Pad
 		// thing from the QtQuick Image link below.
@@ -603,7 +593,31 @@ ButtonBase {
 		height: parent.height/1.6
 		width: parent.width/1.6
 	}
+	
+	background: ShaderEffectSource {
+		
+		// Trying to use ShaderEffectSource to show tile backgrounds.
+		// Docs on ShaderEffectSource:
+		// https://doc.qt.io/qt-6/qml-qtquick-shadereffectsource.html
+		
+		sourceItem: tileWallpaper
+		sourceRect: Qt.rect(parent.x, parent.y, parent.width, parent.height)
+		recursive: true
+		hideSource: true
 		
 	}
+	
+	//background: Rectangle {
+	//	// Change tile color and stuff.
+	//	color: tileBackgroundColor
+	//	border.width: 0
+	//	radius: 0
+		
+	//	// Add antialiasing to tiles.
+	//	// TODO: Allow buttons to have antialiasing turned
+	//	// off, if desired by the user in the settings.
+	//	antialiasing: true
+
+	//}
 	
 }

--- a/RetiledStyles/TileBackgroundShaderEffectSource.qml
+++ b/RetiledStyles/TileBackgroundShaderEffectSource.qml
@@ -1,0 +1,40 @@
+import QtQuick
+
+ShaderEffectSource {
+		
+		// Trying to use ShaderEffectSource to show tile backgrounds.
+		// Docs on ShaderEffectSource:
+		// https://doc.qt.io/qt-6/qml-qtquick-shadereffectsource.html
+		
+		// Use the tile wallpaper for the source to put as the tile background.
+		// I tried multiplying the width and height by the parent's scale (the tile's scale, that is),
+		// and it's a little weird. There needs to be a way to have the background ignore
+		// changes to scale and tilt, but I'm not sure what to do.
+		// TODO: Figure out how to have it so that pressing a tile doesn't change
+		// the "scale" of the part of the wallpaper shown on a tile
+		// and instead "zooms in" and crops the visible part of the shader
+		// effect source. Also do this for the tilt.
+		sourceItem: tileWallpaper
+		// Cut out parts of the wallpaper for each tile.
+		// Here we're taking the current tile's X-value for the
+		// shader effect source's X-value, then (this is complicated)
+		// we add the top spacer above the tiles so that the image
+		// at least shows behind all the tiles at the top, then we take
+		// that and add it to the result of the height of the tilesFlickable (what you
+		// interact with when scrolling through the tiles) divided by the window's height
+		// added to the inverse/negative of the tilesFlickable's current contentY-value,
+		// then we add all that to the tile's Y-value, and finally subtract the tile wallpaper's
+		// current Y-value from it.
+		// The last two are simple: just the tile's width and height.
+		// This will result in the tile wallpaper (assigned as tileWallpaper.source, usually
+		// in "Tiles.qml", but you can use your own Image source if you're using this in
+		// your own app) scrolling "through" the tiles as if they were a window, like
+		// in Windows Phone 8.1.
+		// (This doesn't quite work if the window is too short/wide/skinny/tall and
+		// the image isn't the right aspect ratio to fill it in; maybe we can
+		// use a different fillMode or make it go slower if the window is smaller/larger?)
+		sourceRect: Qt.rect(control.x, tilesPageTopSpacer.height + (-tilesFlickable.contentY + tilesFlickable.height / window.height) + control.y - tileWallpaper.y, control.width, control.height)
+		// Hide the image source.
+		hideSource: true
+		
+}

--- a/RetiledStyles/TileBackgroundShaderEffectSource.qml
+++ b/RetiledStyles/TileBackgroundShaderEffectSource.qml
@@ -73,6 +73,7 @@ ShaderEffectSource {
 		// (This doesn't quite work if the window is too short/wide/skinny/tall and
 		// the image isn't the right aspect ratio to fill it in; maybe we can
 		// use a different fillMode or make it go slower if the window is smaller/larger?)
+		// TODO: Fix the image starting to disappear when there are too many tiles.
 		sourceRect: Qt.rect(control.x, tilesPageTopSpacer.height + (-tilesFlickable.contentY + tilesFlickable.height / window.height) + control.y - tileWallpaper.y, control.width, control.height)
 		// Hide the image source.
 		hideSource: true

--- a/RetiledStyles/TileBackgroundShaderEffectSource.qml
+++ b/RetiledStyles/TileBackgroundShaderEffectSource.qml
@@ -42,6 +42,11 @@ import QtQuick
 
 ShaderEffectSource {
 		
+		// This is the tile wallpaper object/element,
+		// with a background image as introduced in 8.1.
+		// To see the code for the tile background images,
+		// please open "TileBackgroundSolidColorRectangle.qml".
+		
 		// Trying to use ShaderEffectSource to show tile backgrounds.
 		// Docs on ShaderEffectSource:
 		// https://doc.qt.io/qt-6/qml-qtquick-shadereffectsource.html
@@ -77,5 +82,5 @@ ShaderEffectSource {
 		sourceRect: Qt.rect(control.x, tilesPageTopSpacer.height + (-tilesFlickable.contentY + tilesFlickable.height / window.height) + control.y - tileWallpaper.y, control.width, control.height)
 		// Hide the image source.
 		hideSource: true
-		
+		// Unfortunately, the tiles seem not very aliased, at least in Windows 10.
 }

--- a/RetiledStyles/TileBackgroundShaderEffectSource.qml
+++ b/RetiledStyles/TileBackgroundShaderEffectSource.qml
@@ -1,3 +1,43 @@
+// RetiledStyles - Windows Phone 8.x-like QML styles for the
+//                 Retiled project. Some code was copied from
+//                 the official qtdeclarative repo, which you can
+//                 access a copy of here:
+//                 https://github.com/DrewNaylor/qtdeclarative
+// Copyright (C) 2021-2023 Drew Naylor
+// (Note that the copyright years include the years left out by the hyphen.)
+// Windows Phone and all other related copyrights and trademarks are property
+// of Microsoft Corporation. All rights reserved.
+//
+// This file is a part of the RetiledStyles project, which is used by Retiled.
+// Neither Retiled nor Drew Naylor are associated with Microsoft
+// and Microsoft does not endorse Retiled.
+// Any other copyrights and trademarks belong to their
+// respective people and companies/organizations.
+//
+//
+//    RetiledStyles is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License
+//    version 3 as published by the Free Software Foundation.
+//    All files in this repo (Retiled) licensed under the Apache License, 2.0,
+//    are using RetiledStyles under the LGPLv3.
+//
+//    Alternatively, this file may be used under the terms of the GNU
+//    General Public License version 2.0 or later as published by the Free
+//    Software Foundation and appearing in the file LICENSE.GPL included in
+//    the packaging of this file. Please review the following information to
+//    ensure the GNU General Public License version 2.0 requirements will be
+//    met: http://www.gnu.org/licenses/gpl-2.0.html.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU (Lesser) General Public License for more details.
+//
+//    You should have received a copy of the GNU (Lesser) General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
 import QtQuick
 
 ShaderEffectSource {

--- a/RetiledStyles/TileBackgroundSolidColorRectangle.qml
+++ b/RetiledStyles/TileBackgroundSolidColorRectangle.qml
@@ -1,3 +1,43 @@
+// RetiledStyles - Windows Phone 8.x-like QML styles for the
+//                 Retiled project. Some code was copied from
+//                 the official qtdeclarative repo, which you can
+//                 access a copy of here:
+//                 https://github.com/DrewNaylor/qtdeclarative
+// Copyright (C) 2021-2023 Drew Naylor
+// (Note that the copyright years include the years left out by the hyphen.)
+// Windows Phone and all other related copyrights and trademarks are property
+// of Microsoft Corporation. All rights reserved.
+//
+// This file is a part of the RetiledStyles project, which is used by Retiled.
+// Neither Retiled nor Drew Naylor are associated with Microsoft
+// and Microsoft does not endorse Retiled.
+// Any other copyrights and trademarks belong to their
+// respective people and companies/organizations.
+//
+//
+//    RetiledStyles is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License
+//    version 3 as published by the Free Software Foundation.
+//    All files in this repo (Retiled) licensed under the Apache License, 2.0,
+//    are using RetiledStyles under the LGPLv3.
+//
+//    Alternatively, this file may be used under the terms of the GNU
+//    General Public License version 2.0 or later as published by the Free
+//    Software Foundation and appearing in the file LICENSE.GPL included in
+//    the packaging of this file. Please review the following information to
+//    ensure the GNU General Public License version 2.0 requirements will be
+//    met: http://www.gnu.org/licenses/gpl-2.0.html.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU (Lesser) General Public License for more details.
+//
+//    You should have received a copy of the GNU (Lesser) General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
 Rectangle {
 			// Change tile color and stuff.
 			color: tileBackgroundColor

--- a/RetiledStyles/TileBackgroundSolidColorRectangle.qml
+++ b/RetiledStyles/TileBackgroundSolidColorRectangle.qml
@@ -1,0 +1,11 @@
+Rectangle {
+			// Change tile color and stuff.
+			color: tileBackgroundColor
+			border.width: 0
+			radius: 0
+		
+			//	// Add antialiasing to tiles.
+			//	// TODO: Allow buttons to have antialiasing turned
+			//	// off, if desired by the user in the settings.
+			antialiasing: true
+			}

--- a/RetiledStyles/TileBackgroundSolidColorRectangle.qml
+++ b/RetiledStyles/TileBackgroundSolidColorRectangle.qml
@@ -39,13 +39,20 @@
 
 import QtQuick
 Rectangle {
-			// Change tile color and stuff.
-			color: tileBackgroundColor
-			border.width: 0
-			radius: 0
-		
-			//	// Add antialiasing to tiles.
-			//	// TODO: Allow buttons to have antialiasing turned
-			//	// off, if desired by the user in the settings.
-			antialiasing: true
-			}
+	
+	// This is the regular tile background object/element,
+	// with the solid color like WP7.x-8.0 before
+	// tile background images were introduced in 8.1.
+	// To see the code for the tile background images,
+	// please open "TileBackgroundShaderEffectSource.qml".
+	
+	// Change tile color and stuff.
+	color: tileBackgroundColor
+	border.width: 0
+	radius: 0
+	
+	// Add antialiasing to tiles.
+	// TODO: Allow buttons to have antialiasing turned
+	// off, if desired by the user in the settings.
+	antialiasing: true
+}

--- a/RetiledStyles/TileBackgroundSolidColorRectangle.qml
+++ b/RetiledStyles/TileBackgroundSolidColorRectangle.qml
@@ -37,7 +37,7 @@
 //    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-
+import QtQuick
 Rectangle {
 			// Change tile color and stuff.
 			color: tileBackgroundColor


### PR DESCRIPTION
There's now initial support for parallax tile wallpapers (the in-tile ones from 8.1), as well as ordinary parallax wallpapers that go behind tiles. To use the tile wallpaper, set both `displayBackgroundWallpaper` and `useTileBackgroundWallpaper` to `true` in `./RetiledStart/RetiledStart/pages/Tiles.qml`. To use the ordinary wallpaper, set `displayBackgroundWallpaper` to `true` and `useTileBackgroundWallpaper` to `false` (also in `./RetiledStart/RetiledStart/pages/Tiles.qml`). **Please note** that there are some issues with wallpapers right now, mainly that they start to disappear if too many tiles are pinned and the image isn't large enough to cover them all (most noticeable with the ordinary wallpaper style, but still happens with the tile wallpapers; the ordinary style also can show a blank area above the tiles area if you scroll up so the overshoot area is showing). Another issue is that the image changes its size and rotation when tiles are pressed, if using tile wallpapers (this isn't supposed to happen, instead, it's supposed to "crop" the image).

To change your wallpaper, either replace `./RetiledStart/RetiledStart/pages/wallpaper.jpg` with another image (may need to restart RetiledStart), or manually edit the code in `Tiles.qml` where we're loading the wallpaper into an Image (just search for `source: "wallpaper.jpg"` and you should find it; if not, try searching for just `source:` and it should appear eventually).

Configuration options will eventually be added for all these settings, so you won't have to manually edit the code. Additionally, I also plan to add accessibility options to turn off the parallax effect.

The way tile wallpapers will work is they'll be used if a tile's background color is the same as the user's Accent color, and if not, they'll use the solid background color. This behavior is just like Windows Phone 8.1 (and I assume Windows 10 Mobile, because changing it wouldn't make sense). Tiles will be able to define their background color in their app's .desktop file in an `[X-Retiled-LiveTile]` section; this is yet to be implemented.